### PR TITLE
Ensure viewId is incremented at end only

### DIFF
--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
@@ -201,7 +201,6 @@
 - (void)sendRequest {
     if ([self.state goRequest]) {
         self.playtimeSinceLastEventTimestamp = 0;
-        self.viewIdIndex++;
         
         if (self.state.isAd) {
             [self sendEvent:AD_REQUEST];
@@ -274,6 +273,7 @@
         
         [self stopHeartbeat];
         
+        self.viewIdIndex++;
         self.numberOfErrors = 0;
         self.playtimeSinceLastEventTimestamp = 0;
         self.playtimeSinceLastEvent = 0;


### PR DESCRIPTION
## 📄 Description

`viewId` is extrapolated out of the `viewSessionId` by appending an incremented integer to it to isolate subsequent playback within the same tracker.

All is good until consumer of the library uses custom events prior to the initial play event of their video player. This causes custom events to be reported under `viewId-0` while the rest of the playback events will be stored under `viewId-1`.

## ⛑️  Fix

By simply not incrementing the `viewId` during `sendRequest`, but rather do it on sendEnd, we end up having the expected behavior where all events are stored under the same `viewId`.

## 🖼️ Results

`CONTENT_MANIFEST_REQUEST` being a custom event sent prior to the first sendRequest(), we see in this screenshot that is now bound to the proper viewId: 
<img width="1669" alt="Screenshot 2023-05-25 at 2 53 15 PM" src="https://github.com/newrelic/video-agent-iOS/assets/513491/16640e34-1271-41b7-8de9-4af5020a4877">
