### PR TITLE
Add seeking events during playback with seek bufferType

### DIFF
--- a/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
+++ b/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
@@ -215,6 +215,11 @@
         if (!self.state.isBuffering && self.state.isPaused && self.playerInstance.rate == 0.0) {
             [self sendSeekStart];
         }
+        // The state isSeekingDuringPlayback can be set manually using the setIsSeekingDuringPlayback function
+        // Otherwise, KVO observers are not being notified that a seek happened during playback (rate == 1.0)
+        else if (!self.state.isBuffering && self.state.isSeekingDuringPlayback && !self.state.isPaused && self.playerInstance.rate == 1.0) {            
+            [self sendSeekStart];
+        }
     }
     else if ([keyPath isEqualToString:@"currentItem.playbackLikelyToKeepUp"]) {
         [self sendRequest];

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerState.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerState.h
@@ -20,6 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reset;
 
 /**
+ Set the state isSeekingDuringPlayback.
+ This function has to be called at least when seeking occurs during playback because the KVO observer methods will not catch this type of seek.
+ */
+- (void)setIsSeekingDuringPlayback;
+
+/**
  Return state isPlayerReady.
  
  @return state..
@@ -60,6 +66,13 @@ NS_ASSUME_NONNULL_BEGIN
  @return state..
  */
 - (BOOL)isSeeking;
+
+/**
+ Return state isSeekingDuringPlayback.
+ 
+ @return state..
+ */
+- (BOOL)isSeekingDuringPlayback;
 
 /**
  Return state isBuffering.

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerState.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerState.m
@@ -15,6 +15,7 @@
 @property (nonatomic) BOOL isPlaying;
 @property (nonatomic) BOOL isPaused;
 @property (nonatomic) BOOL isSeeking;
+@property (nonatomic) BOOL isSeekingDuringPlayback;
 @property (nonatomic) BOOL isBuffering;
 @property (nonatomic) BOOL isAd;
 @property (nonatomic) BOOL isAdBreak;
@@ -37,9 +38,19 @@
     self.isPlaying = NO;
     self.isPaused = NO;
     self.isSeeking = NO;
+    self.isSeekingDuringPlayback = NO;
     self.isBuffering = NO;
     self.isAd = NO;
     self.isAdBreak = NO;
+}
+
+- (void)setIsSeekingDuringPlayback {
+    if (self.isPlaying) {
+        self.isSeekingDuringPlayback = true;
+    }
+    else {
+        self.isSeekingDuringPlayback = false;
+    }
 }
 
 - (BOOL)goPlayerReady {
@@ -144,6 +155,7 @@
 - (BOOL)goSeekEnd {
     if (self.isStarted && self.isSeeking) {
         self.isSeeking = false;
+        self.isSeekingDuringPlayback = false;
         self.isPlaying = true;
         return true;
     }


### PR DESCRIPTION
## 📖 Description & Context

On iOS, no events were sent to NewRelic when seeking occurred during playback. (see [🎉 Results](#-results) below). The only seek events received were happening when playback was paused (rate = 0.0).

I made some research and I did not find a way to distinguish that a seek happened when the player is playing (rate = 1.0) with the KVO methods used in the `NRVideoTracker` to send seek events during playback.

That being said, if there is a way to know that a seek happened even during playback using the KVO observer methods, please let me know. 

## 👷 Fix
Otherwise, I propose adding a state (`isSeekingDuringPlayback`) that we can manually set when we record a seek during playback from the user on our side. Then, it makes it possible to:
* Send `CONTENT_SEEK_START` and `CONTENT_SEEK_END`.
* Send `CONTENT_BUFFER_START` and `CONTENT_BUFFER_END` with their `bufferType = seek` rather than `connection`.

## 🎉 Results
The actions performed on the player before and after this fix are:
* PLAY   ➡️    SEEK WHILE   ➡️   PLAYING PAUSE

### Before
![image](https://github.com/mirego/bellmedia-jasper/assets/36643033/ddf7e33f-726a-45a2-8c1e-b782661afe62)

### After
![image](https://github.com/mirego/bellmedia-jasper/assets/36643033/11d2a303-90d1-4449-b954-04e857895c01)