### PR TITLE
Handle correctly seek events while paused

### DIFF
--- a/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
+++ b/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
@@ -97,6 +97,11 @@
     @catch (id e) {}
     
     @try {
+        [self.state removeObserver:self forKeyPath:@"isUserSeeking"];
+    }
+    @catch (id e) {}
+    
+    @try {
         [self.playerInstance removeTimeObserver:self.timeObserver];
         self.timeObserver = nil;
     }
@@ -176,6 +181,11 @@
                      options:NSKeyValueObservingOptionNew
                      context:NULL];
     
+    [self.state addObserver:self
+                  forKeyPath:@"isUserSeeking"
+                     options:NSKeyValueObservingOptionNew
+                     context:NULL];
+    
     self.timeObserver =
     [self.playerInstance addPeriodicTimeObserverForInterval:CMTimeMake(1, 2) queue:NULL usingBlock:^(CMTime time) {
         
@@ -210,19 +220,26 @@
                        context:(void *)context {
     
     AV_LOG(@"(AVPlayerTracker) Observed keyPath = %@ , object = %@ , change = %@ , context = %@", keyPath, object, change, context);
-    
-    if ([keyPath isEqualToString:@"currentItem.playbackBufferEmpty"]) {
-        if (!self.state.isBuffering && self.state.isPaused && self.playerInstance.rate == 0.0) {
-            [self sendSeekStart];
-        }
-        // The state isSeekingDuringPlayback can be set manually using the setIsSeekingDuringPlayback function
-        // Otherwise, KVO observers are not being notified that a seek happened during playback (rate == 1.0)
-        else if (!self.state.isBuffering && self.state.isSeekingDuringPlayback && !self.state.isPaused && self.playerInstance.rate == 1.0) {            
+    // User seek event sent by the integrators
+    if ([keyPath isEqualToString:@"isUserSeeking"]) {
+        if (self.state.isUserSeeking) {
             [self sendSeekStart];
         }
     }
+    else if ([keyPath isEqualToString:@"currentItem.playbackBufferEmpty"] && self.state.isSeeking && self.state.isPaused) {
+        [self sendBufferStart];
+    }
+    else if ([keyPath isEqualToString:@"currentItem.playbackBufferFull"] && self.state.isSeeking && self.state.isPaused) {
+        [self sendBufferEnd];
+        [self sendSeekEnd];
+    }
     else if ([keyPath isEqualToString:@"currentItem.playbackLikelyToKeepUp"]) {
         [self sendRequest];
+
+        if (self.state.isSeeking && self.state.isPaused && self.playerInstance.currentItem.playbackLikelyToKeepUp) {
+            [self sendBufferEnd];
+            [self sendSeekEnd];
+        }
     }
     else if ([keyPath isEqualToString:@"status"]) {
         if (self.playerInstance.status == AVPlayerItemStatusReadyToPlay) {
@@ -255,6 +272,7 @@
             }
             else {
                 [self sendBufferEnd];
+                [self sendSeekEnd];
             }
         } else {
             // Fallback on earlier versions
@@ -459,7 +477,6 @@
 
 - (void)sendResume {
     //Make sure we close the previous blocks
-    [self sendSeekEnd];
     // Send RESUME
     [super sendResume];
     

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerState.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerState.h
@@ -20,10 +20,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reset;
 
 /**
- Set the state isSeekingDuringPlayback.
- This function has to be called at least when seeking occurs during playback because the KVO observer methods will not catch this type of seek.
+ Set the state isUserSeeking to true.
+ This function has to be called whenever a seek event occurs during playback.
  */
-- (void)setIsSeekingDuringPlayback;
+- (void)startSeekingEvent;
 
 /**
  Return state isPlayerReady.
@@ -68,11 +68,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isSeeking;
 
 /**
- Return state isSeekingDuringPlayback.
+ Return state isUserSeeking.
  
  @return state..
  */
-- (BOOL)isSeekingDuringPlayback;
+- (BOOL)isUserSeeking;
 
 /**
  Return state isBuffering.

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerState.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerState.m
@@ -15,7 +15,7 @@
 @property (nonatomic) BOOL isPlaying;
 @property (nonatomic) BOOL isPaused;
 @property (nonatomic) BOOL isSeeking;
-@property (nonatomic) BOOL isSeekingDuringPlayback;
+@property (nonatomic) BOOL isUserSeeking;
 @property (nonatomic) BOOL isBuffering;
 @property (nonatomic) BOOL isAd;
 @property (nonatomic) BOOL isAdBreak;
@@ -38,19 +38,14 @@
     self.isPlaying = NO;
     self.isPaused = NO;
     self.isSeeking = NO;
-    self.isSeekingDuringPlayback = NO;
+    self.isUserSeeking = NO;
     self.isBuffering = NO;
     self.isAd = NO;
     self.isAdBreak = NO;
 }
 
-- (void)setIsSeekingDuringPlayback {
-    if (self.isPlaying) {
-        self.isSeekingDuringPlayback = true;
-    }
-    else {
-        self.isSeekingDuringPlayback = false;
-    }
+- (void)startSeekingEvent {
+    self.isUserSeeking = true;
 }
 
 - (BOOL)goPlayerReady {
@@ -91,6 +86,7 @@
         self.isPlaying = NO;
         self.isPaused = NO;
         self.isSeeking = NO;
+        self.isUserSeeking = NO;
         self.isBuffering = NO;
         return true;
     }
@@ -155,7 +151,7 @@
 - (BOOL)goSeekEnd {
     if (self.isStarted && self.isSeeking) {
         self.isSeeking = false;
-        self.isSeekingDuringPlayback = false;
+        self.isUserSeeking = false;
         self.isPlaying = true;
         return true;
     }


### PR DESCRIPTION
## 📖 Description & Context

On iOS, a fix has been recently done to the video tracker in order to improve the seek events. What was done in https://github.com/newrelic/video-agent-iOS/pull/20: 
* Send `CONTENT_SEEK_START` and `CONTENT_SEEK_END` events.
* Send `CONTENT_BUFFER_START` and `CONTENT_BUFFER_END` with their `bufferType = seek` rather than `connection` when seek occurs.

⚠️ However, this fix did **not cover correctly** when a user made a seek during the pause state. 
* The `CONTENT_SEEK_END` event was only sent once the playback was resumed. That behavior was corrupting the `timeSinceSeekBegin` timer.
* Also, when paused, the `CONTENT_BUFFER_START` and `CONTENT_BUFFER_END` events were simply not sent, while it's still not possible to directly resume playback for a certain buffer time.

## 👷 Fix
Modified the state `isSeekingDuringPlayback` for `isUserSeeking`. With this solution, the lib integrators are now 100% handling when a seek event starts (on a user seek interaction). Then, with the KVO observers, the tracker is handling by itself when the seek ends as well as its buffer. So, right now:

* `CONTENT_SEEK_START` and `CONTENT_SEEK_END` events are sent when paused (without the need to restart the playback).
* `CONTENT_BUFFER_START` and `CONTENT_BUFFER_END` events are sent when the player stays in a pause state. The `CONTENT_BUFFER_END` is sent when it's possible for the user to resume playback without any loading time (which is when the observer `playbackLikelyToKeepUp` changes to `true` during the pause state while seeking).

## 📓 Notes about this solution
* I first tried to handle manually when seek started AND when seek ended on the integrator side, but if the `CONTENT_SEEK_END` was not handled by the tracker on par with the buffer events, it was leading to certain race conditions and unwanted behaviors.
* When a user spams the seek button many times, it may request some subsequent seek actions while a previous seek buffer is not completed. In that case, these subsequent seeks will be part of the latest `SEND_SEEK_START`, `SEND_SEEK_END` and its buffer start/end.