### PR TITLE
Adjust player rate check over 0.0

### DIFF
--- a/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
+++ b/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
@@ -187,7 +187,7 @@
         // If duration is NaN, then is live streaming. Otherwise is VoD.
         self.isLive = isnan(CMTimeGetSeconds(self.playerInstance.currentItem.duration));
         
-        if (self.playerInstance.rate == 1.0) {
+        if (self.playerInstance.rate > 0.0) {
             [self sendStart];
             [self sendBufferEnd];
             [self sendResume];


### PR DESCRIPTION
## 📖 Description & Context

On iOS, the AVPlayer playback speed can be set to pretty much anything between 0.5 and 2.0. With that in mind, there's a certain condition that can't be reached if the player is set on a different player rate than 1.0.

## 👷 Fix
* Fulfill the condition simply when the player rate is over 0.0.