### PR TITLE
feat: Update bitrate key

### DIFF
--- a/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
+++ b/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
@@ -395,7 +395,7 @@
 
 - (NSNumber *)getBitrate {
     AVPlayerItemAccessLogEvent *event = [self.playerInstance.currentItem.accessLog.events lastObject];
-    return @(event.averageVideoBitrate);
+    return @(event.observedBitrate);
 }
 
 - (NSNumber *)getRenditionWidth {

--- a/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
+++ b/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
@@ -395,7 +395,7 @@
 
 - (NSNumber *)getBitrate {
     AVPlayerItemAccessLogEvent *event = [self.playerInstance.currentItem.accessLog.events lastObject];
-    return @(event.indicatedBitrate);
+    return @(event.averageVideoBitrate);
 }
 
 - (NSNumber *)getRenditionWidth {


### PR DESCRIPTION
It is discussed that current key used for content bitrate in ios is indicatedBitrate and this is changed to [averageVideoBitrate](https://developer.apple.com/documentation/avfoundation/avplayeritemaccesslogevent/averagevideobitrate?language=objc)