### PR TITLE
fix: Fire end event for Ad skip

### DIFF
--- a/NRIMATracker/NRIMATracker/Tracker/NRTrackerIMA.m
+++ b/NRIMATracker/NRIMATracker/Tracker/NRTrackerIMA.m
@@ -14,6 +14,7 @@
 @property (nonatomic, weak) IMAAdEvent *lastEvent;
 @property (nonatomic, weak) IMAAdsManager *adsManager;
 @property (nonatomic) NSNumber *quartile;
+@property (nonatomic) NSNumber *skipped;
 
 @end
 
@@ -22,6 +23,7 @@
 - (instancetype)init {
     if (self = [super init]) {
         self.quartile = nil;
+        self.skipped = 0;
     }
     return self;
 }
@@ -34,6 +36,11 @@
         self.quartile = @(0);
         [self sendRequest];
         [self sendStart];
+    }
+    else if([event.typeString isEqual:@"Skipped"] ){
+        self.skipped = @1;
+        [self sendEnd];
+        self.quartile = nil;
     }
     else if ([event.typeString isEqual:@"Complete"]) {
         [self sendEnd];
@@ -171,6 +178,10 @@
 
 - (NSNumber *)getAdQuartile {
     return self.quartile ? self.quartile : (NSNumber *)[NSNull null];
+}
+
+- (NSNumber *)getAdSkipped {
+    return self.skipped;
 }
 
 //TODO: - (NSString *)getAdPartner

--- a/NRIMATracker/NRIMATracker/Tracker/NRTrackerIMA.m
+++ b/NRIMATracker/NRIMATracker/Tracker/NRTrackerIMA.m
@@ -23,7 +23,7 @@
 - (instancetype)init {
     if (self = [super init]) {
         self.quartile = nil;
-        self.skipped = 0;
+        self.skipped = @(0);
     }
     return self;
 }
@@ -38,7 +38,7 @@
         [self sendStart];
     }
     else if([event.typeString isEqual:@"Skipped"] ){
-        self.skipped = @1;
+        self.skipped = @(1);
         [self sendEnd];
         self.quartile = nil;
     }

--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.h
@@ -297,6 +297,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)getAdBreakId;
 
 /**
+ Get ad skipped
+ 
+ @return true if ad is skipped.
+ */
+- (NSString *)getAdSkipped;
+
+/**
  Get total ad playtime of the last ad break.
  
  @return Attribute.

--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.h
@@ -299,9 +299,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Get ad skipped
  
- @return true if ad is skipped.
+ @return 1 if ad is skipped.
  */
-- (NSString *)getAdSkipped;
+- (NSNumber *)getAdSkipped;
 
 /**
  Get total ad playtime of the last ad break.

--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
@@ -526,7 +526,7 @@
 }
 
 - (NSNumber *)getAdSkipped {
-    return (NSNumber *)[NSNull null];
+    return @(0);
 }
 
 - (NSNumber *)getTotalAdPlaytime {

--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
@@ -155,6 +155,7 @@
         [attr setObject:[self getAdPartner] forKey:@"adPartner"];
         [attr setObject:[self getVideoId] forKey:@"adId"];
         [attr setObject:[self getAdBreakId] forKey:@"adBreakId"];
+        [attr setObject:[self getAdSkipped] forKey:@"adSkipped"];
         
         if ([action hasPrefix:@"AD_BREAK_"]) {
             if ([self.linkedTracker isKindOfClass:[NRVideoTracker class]]) {
@@ -522,6 +523,10 @@
 
 - (NSString *)getAdBreakId {
     return [NSString stringWithFormat:@"%@-%d", [self getViewSession], self.adBreakIdIndex];
+}
+
+- (NSNumber *)getAdSkipped {
+    return (NSNumber *)[NSNull null];
 }
 
 - (NSNumber *)getTotalAdPlaytime {


### PR DESCRIPTION
Fix: Ad skip now triggers AD_END, terminating AD_HEARTBEAT and resolving persistent heartbeat issue.