### PR TITLE
Feat: QOE Attributes

### DIFF
--- a/Examples/iOS/PiPExampleSwift/PiPExampleSwift/Base.lproj/Main.storyboard
+++ b/Examples/iOS/PiPExampleSwift/PiPExampleSwift/Base.lproj/Main.storyboard
@@ -16,8 +16,25 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-stack-view">
+                                <rect key="frame" x="100" y="54" width="214" height="61.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable QOE Aggregate" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-label">
+                                        <rect key="frame" x="32" y="0.0" width="150" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-switch">
+                                        <rect key="frame" x="82.5" y="28.5" width="51" height="31"/>
+                                        <connections>
+                                            <action selector="qoeSwitchChangedWithSender:" destination="BYZ-38-t0r" eventType="valueChanged" id="qoe-switch-action"/>
+                                        </connections>
+                                    </switch>
+                                </subviews>
+                            </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="50W-oq-dv4">
-                                <rect key="frame" x="185.5" y="89" width="43" height="30"/>
+                                <rect key="frame" x="185.5" y="135.5" width="43" height="30"/>
                                 <state key="normal" title="Bunny"/>
                                 <connections>
                                     <action selector="clickPlayBunnyWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mu4-uj-EfE"/>
@@ -27,10 +44,15 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="50W-oq-dv4" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="45" id="IDN-EU-xLg"/>
+                            <constraint firstItem="qoe-stack-view" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="qoe-stack-top"/>
+                            <constraint firstItem="qoe-stack-view" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="qoe-stack-centerX"/>
+                            <constraint firstItem="50W-oq-dv4" firstAttribute="top" secondItem="qoe-stack-view" secondAttribute="bottom" constant="20" id="IDN-EU-xLg"/>
                             <constraint firstItem="50W-oq-dv4" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="zv4-qX-dBN"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="qoeSwitch" destination="qoe-switch" id="qoe-switch-outlet"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Examples/iOS/PiPExampleSwift/PiPExampleSwift/ViewController.swift
+++ b/Examples/iOS/PiPExampleSwift/PiPExampleSwift/ViewController.swift
@@ -16,6 +16,9 @@ class ViewController: UIViewController, AVPlayerViewControllerDelegate {
     private var trackerId: Int = 0
     private var inPiP: Bool = false
 
+    // QOE Toggle
+    @IBOutlet weak var qoeSwitch: UISwitch!
+
     // IMA Ad Properties
     private var adsLoader: IMAAdsLoader?
     private var adsManager: IMAAdsManager?
@@ -28,7 +31,21 @@ class ViewController: UIViewController, AVPlayerViewControllerDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        // Initialize QOE switch to match current configuration
+        qoeSwitch.isOn = NRVAVideo.isQoeAggregateEnabled()
+    }
+
+    @IBAction func qoeSwitchChanged(_ sender: UISwitch) {
+        NRVAVideo.setQoeAggregateEnabled(sender.isOn)
+
+        let message = sender.isOn ? "QOE Aggregate Enabled" : "QOE Aggregate Disabled"
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        present(alert, animated: true)
+
+        // Auto-dismiss after 1 second
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            alert.dismiss(animated: true)
+        }
     }
 
     func playVideo(videoURL: String) {

--- a/Examples/iOS/SimplePlayerUsingPods/SimplePlayerUsingPods/Base.lproj/Main.storyboard
+++ b/Examples/iOS/SimplePlayerUsingPods/SimplePlayerUsingPods/Base.lproj/Main.storyboard
@@ -16,8 +16,25 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-stack-view">
+                                <rect key="frame" x="100" y="54" width="214" height="61.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable QOE Aggregate" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-label">
+                                        <rect key="frame" x="32" y="0.0" width="150" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-switch">
+                                        <rect key="frame" x="82.5" y="28.5" width="51" height="31"/>
+                                        <connections>
+                                            <action selector="qoeSwitchChanged:" destination="BYZ-38-t0r" eventType="valueChanged" id="qoe-switch-action"/>
+                                        </connections>
+                                    </switch>
+                                </subviews>
+                            </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iII-oe-tup">
-                                <rect key="frame" x="185.5" y="64" width="43" height="30"/>
+                                <rect key="frame" x="185.5" y="135.5" width="43" height="30"/>
                                 <state key="normal" title="Bunny"/>
                                 <connections>
                                     <action selector="clickBunnyVideo:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hjQ-KU-Pkq"/>
@@ -48,8 +65,10 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="qoe-stack-view" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="qoe-stack-top"/>
+                            <constraint firstItem="qoe-stack-view" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="qoe-stack-centerX"/>
                             <constraint firstItem="suR-aY-bKa" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="5lC-R0-DCE"/>
-                            <constraint firstItem="iII-oe-tup" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="8k7-Tu-H70"/>
+                            <constraint firstItem="iII-oe-tup" firstAttribute="top" secondItem="qoe-stack-view" secondAttribute="bottom" constant="20" id="8k7-Tu-H70"/>
                             <constraint firstItem="iII-oe-tup" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="FRI-W1-zHc"/>
                             <constraint firstItem="gN7-1c-zoY" firstAttribute="top" secondItem="iII-oe-tup" secondAttribute="bottom" constant="8" symbolic="YES" id="f8g-kn-Rd5"/>
                             <constraint firstItem="suR-aY-bKa" firstAttribute="top" secondItem="gN7-1c-zoY" secondAttribute="bottom" constant="8" symbolic="YES" id="h7F-1K-QSv"/>
@@ -58,6 +77,9 @@
                             <constraint firstItem="HKy-DA-3hh" firstAttribute="top" secondItem="suR-aY-bKa" secondAttribute="bottom" constant="8" symbolic="YES" id="tnN-X7-75i"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="qoeSwitch" destination="qoe-switch" id="qoe-switch-outlet"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Examples/iOS/SimplePlayerUsingPods/SimplePlayerUsingPods/ViewController.m
+++ b/Examples/iOS/SimplePlayerUsingPods/SimplePlayerUsingPods/ViewController.m
@@ -8,11 +8,13 @@
 #import "ViewController.h"
 #import <NewRelicVideoCore/NRVAVideo.h>
 #import <NewRelicVideoCore/NRVAVideoPlayerConfiguration.h>
+#import <UIKit/UIKit.h>
 
 @import AVKit;
 
 @interface ViewController ()
 
+@property (weak, nonatomic) IBOutlet UISwitch *qoeSwitch;
 @property (nonatomic) AVPlayerViewController *playerController;
 @property (nonatomic) NSInteger trackerId;
 
@@ -38,7 +40,27 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+
+    // Initialize QOE switch to match current configuration
+    self.qoeSwitch.on = [NRVAVideo isQoeAggregateEnabled];
+
     NSLog(@"🎬 [ViewController] Simple Player - Ready for video tracking");
+}
+
+- (IBAction)qoeSwitchChanged:(UISwitch *)sender {
+    [NRVAVideo setQoeAggregateEnabled:sender.on];
+
+    NSString *message = sender.on ? @"QOE Aggregate Enabled" : @"QOE Aggregate Disabled";
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [self presentViewController:alert animated:YES completion:nil];
+
+    // Auto-dismiss after 1 second
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        [alert dismissViewControllerAnimated:YES completion:nil];
+    });
 }
 
 - (void)dealloc {

--- a/Examples/iOS/SimplePlayerWithAds/Podfile.lock
+++ b/Examples/iOS/SimplePlayerWithAds/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - GoogleAds-IMA-iOS-SDK (3.19.2)
-  - NewRelicVideoAgent (4.0.0)
-  - NRAVPlayerTracker (4.0.0):
+  - NewRelicVideoAgent (4.0.2)
+  - NRAVPlayerTracker (4.0.2):
     - NewRelicVideoAgent
-  - NRIMATracker (4.0.0):
+  - NRIMATracker (4.0.2):
     - GoogleAds-IMA-iOS-SDK
     - GoogleAds-IMA-tvOS-SDK
     - NewRelicVideoAgent
@@ -27,9 +27,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   GoogleAds-IMA-iOS-SDK: 0e817c05ab26f1b9285c80f4a75e1350a916d50b
-  NewRelicVideoAgent: ee0c43d7490ab9d259c04e531f9b7fec95704033
-  NRAVPlayerTracker: 08d98564362d7a83873de2ef4e443e2027b7138a
-  NRIMATracker: 96a64252d8a7f0569c2af1b129bbfbf44353e8ad
+  NewRelicVideoAgent: 72c71854da1b79a864ba867df1ac88619a3d05a6
+  NRAVPlayerTracker: 7dc7afcc0c7c9d60891f627f3035ade0e8f6f2d3
+  NRIMATracker: 70741ad94e5b3375f5999b47c8aa2fa102e6dabb
 
 PODFILE CHECKSUM: 053b07d4805c2a687fc4558c91431e36b579f061
 

--- a/Examples/iOS/SimplePlayerWithAds/SimplePlayerWithAds/Base.lproj/Main.storyboard
+++ b/Examples/iOS/SimplePlayerWithAds/SimplePlayerWithAds/Base.lproj/Main.storyboard
@@ -16,8 +16,25 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-stack-view">
+                                <rect key="frame" x="100" y="54" width="214" height="61.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable QOE Aggregate" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-label">
+                                        <rect key="frame" x="32" y="0.0" width="150" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-switch">
+                                        <rect key="frame" x="82.5" y="28.5" width="51" height="31"/>
+                                        <connections>
+                                            <action selector="qoeSwitchChanged:" destination="BYZ-38-t0r" eventType="valueChanged" id="qoe-switch-action"/>
+                                        </connections>
+                                    </switch>
+                                </subviews>
+                            </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SYT-KN-Mbj">
-                                <rect key="frame" x="185.5" y="89" width="43" height="30"/>
+                                <rect key="frame" x="185.5" y="135.5" width="43" height="30"/>
                                 <state key="normal" title="Bunny"/>
                                 <connections>
                                     <action selector="clickBunnyVideo:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gBu-eA-egY"/>
@@ -41,14 +58,19 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="qoe-stack-view" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="qoe-stack-top"/>
+                            <constraint firstItem="qoe-stack-view" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="qoe-stack-centerX"/>
                             <constraint firstItem="mE9-jZ-GW1" firstAttribute="top" secondItem="SYT-KN-Mbj" secondAttribute="bottom" constant="8" symbolic="YES" id="Ac8-jI-LFT"/>
-                            <constraint firstItem="SYT-KN-Mbj" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="45" id="Pey-Rt-KAw"/>
+                            <constraint firstItem="SYT-KN-Mbj" firstAttribute="top" secondItem="qoe-stack-view" secondAttribute="bottom" constant="20" id="Pey-Rt-KAw"/>
                             <constraint firstItem="SYT-KN-Mbj" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="ewW-Mb-6C4"/>
                             <constraint firstItem="O1G-sW-eRA" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="ixp-1w-3Vs"/>
                             <constraint firstItem="mE9-jZ-GW1" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="sJY-1J-bdG"/>
                             <constraint firstItem="O1G-sW-eRA" firstAttribute="top" secondItem="mE9-jZ-GW1" secondAttribute="bottom" constant="8" symbolic="YES" id="t0d-wV-mJO"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="qoeSwitch" destination="qoe-switch" id="qoe-switch-outlet"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Examples/iOS/SimplePlayerWithAds/SimplePlayerWithAds/ViewController.m
+++ b/Examples/iOS/SimplePlayerWithAds/SimplePlayerWithAds/ViewController.m
@@ -9,9 +9,11 @@
 #import <NewRelicVideoCore.h>
 
 @import AVKit;
+@import UIKit;
 
 @interface ViewController ()
 
+@property (weak, nonatomic) IBOutlet UISwitch *qoeSwitch;
 @property (nonatomic) AVPlayerViewController *playerController;
 @property (nonatomic) NSInteger trackerId;
 @property (nonatomic) NSString *multipleAdTagURL;
@@ -36,14 +38,33 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
+    // Initialize QOE switch to match current configuration
+    self.qoeSwitch.on = [NRVAVideo isQoeAggregateEnabled];
+
     self.multipleAdTagURL = @"http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=xml_vmap1&unviewed_position_start=1&cust_params=sample_ar%3Dpremidpostpod%26deployment%3Dgmf-js&cmsid=496&vid=short_onecue&correlator=";
-    
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                             selector:@selector(appDidBecomeActive:)
                                                  name:UIApplicationDidBecomeActiveNotification
                                                object:nil];
-    
+
+}
+
+- (IBAction)qoeSwitchChanged:(UISwitch *)sender {
+    [NRVAVideo setQoeAggregateEnabled:sender.on];
+
+    NSString *message = sender.on ? @"QOE Aggregate Enabled" : @"QOE Aggregate Disabled";
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [self presentViewController:alert animated:YES completion:nil];
+
+    // Auto-dismiss after 1 second
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        [alert dismissViewControllerAnimated:YES completion:nil];
+    });
 }
 
 - (void)appDidBecomeActive:(NSNotification *)notif {

--- a/Examples/tvOS/SimplePlayer/SimplePlayer/Base.lproj/Main.storyboard
+++ b/Examples/tvOS/SimplePlayer/SimplePlayer/Base.lproj/Main.storyboard
@@ -19,8 +19,27 @@
                         <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-stack-view">
+                                <rect key="frame" x="760" y="8" width="400" height="130"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="QOE Aggregate" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-label">
+                                        <rect key="frame" x="123" y="0.0" width="154" height="38"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="32"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qoe-button">
+                                        <rect key="frame" x="115" y="54" width="170" height="76"/>
+                                        <inset key="contentEdgeInsets" minX="30" minY="15" maxX="30" maxY="15"/>
+                                        <state key="normal" title="ON"/>
+                                        <connections>
+                                            <action selector="qoeTogglePressed:" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="qoe-button-action"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ESQ-Yv-aNf">
-                                <rect key="frame" x="866.5" y="68" width="187" height="86"/>
+                                <rect key="frame" x="866.5" y="162" width="187" height="86"/>
                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                 <state key="normal" title="Bunny"/>
                                 <connections>
@@ -55,16 +74,21 @@
                         <viewLayoutGuide key="safeArea" id="wu6-TO-1qx"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="qoe-stack-view" firstAttribute="top" secondItem="wu6-TO-1qx" secondAttribute="top" constant="8" id="qoe-stack-top"/>
+                            <constraint firstItem="qoe-stack-view" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="qoe-stack-centerX"/>
                             <constraint firstItem="eBz-j1-3H7" firstAttribute="top" secondItem="Ejm-Pf-x88" secondAttribute="bottom" constant="24" symbolic="YES" id="210-B7-nC4"/>
                             <constraint firstItem="Xw0-Uf-55K" firstAttribute="top" secondItem="ESQ-Yv-aNf" secondAttribute="bottom" constant="24" symbolic="YES" id="30x-2V-QLI"/>
                             <constraint firstItem="Ejm-Pf-x88" firstAttribute="top" secondItem="Xw0-Uf-55K" secondAttribute="bottom" constant="24" symbolic="YES" id="99B-RZ-iir"/>
-                            <constraint firstItem="ESQ-Yv-aNf" firstAttribute="top" secondItem="wu6-TO-1qx" secondAttribute="top" constant="8" id="RYB-Ob-yY2"/>
+                            <constraint firstItem="ESQ-Yv-aNf" firstAttribute="top" secondItem="qoe-stack-view" secondAttribute="bottom" constant="24" id="RYB-Ob-yY2"/>
                             <constraint firstItem="eBz-j1-3H7" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="WXG-De-r9z"/>
                             <constraint firstItem="ESQ-Yv-aNf" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="jTW-b8-AD6"/>
                             <constraint firstItem="Ejm-Pf-x88" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="lGZ-yq-CI7"/>
                             <constraint firstItem="Xw0-Uf-55K" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="sMg-9e-sux"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="qoeToggleButton" destination="qoe-button" id="qoe-button-outlet"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Examples/tvOS/SimplePlayer/SimplePlayer/ViewController.m
+++ b/Examples/tvOS/SimplePlayer/SimplePlayer/ViewController.m
@@ -8,13 +8,16 @@
 #import "ViewController.h"
 #import <NewRelicVideoCore/NewRelicVideoCore.h>
 #import <NRAVPlayerTracker/NRAVPlayerTracker.h>
+#import <UIKit/UIKit.h>
 
 @import AVKit;
 
 @interface ViewController ()
 
+@property (weak, nonatomic) IBOutlet UIButton *qoeToggleButton;
 @property (nonatomic) AVPlayerViewController *playerController;
 @property (nonatomic) NSInteger trackerId;
+@property (nonatomic) BOOL qoeEnabled;
 
 @end
 
@@ -38,7 +41,37 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
+    // Initialize QOE state and button
+    self.qoeEnabled = [NRVAVideo isQoeAggregateEnabled];
+    [self updateQoeButtonTitle];
+}
+
+- (void)updateQoeButtonTitle {
+    NSString *title = self.qoeEnabled ? @"ON" : @"OFF";
+    [self.qoeToggleButton setTitle:title forState:UIControlStateNormal];
+}
+
+- (IBAction)qoeTogglePressed:(UIButton *)sender {
+    // Toggle the state
+    self.qoeEnabled = !self.qoeEnabled;
+    [NRVAVideo setQoeAggregateEnabled:self.qoeEnabled];
+
+    // Update button title
+    [self updateQoeButtonTitle];
+
+    // Show alert (tvOS style)
+    NSString *message = self.qoeEnabled ? @"QOE Aggregate Enabled" : @"QOE Aggregate Disabled";
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"QOE Settings"
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK"
+                                                       style:UIAlertActionStyleDefault
+                                                     handler:nil];
+    [alert addAction:okAction];
+
+    [self presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)dealloc {

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.h
@@ -195,6 +195,19 @@
  */
 + (NSInteger)getHarvestCycleSeconds;
 
+/**
+ * Check if QOE (Quality of Experience) aggregate events are enabled
+ * @return YES if enabled, NO if disabled (returns YES if not initialized)
+ */
++ (BOOL)isQoeAggregateEnabled;
+
+/**
+ * Enable or disable QOE (Quality of Experience) aggregate events at runtime
+ * Thread-safe operation that can be called from any thread
+ * @param enabled YES to enable QOE aggregate events, NO to disable
+ */
++ (void)setQoeAggregateEnabled:(BOOL)enabled;
+
 @end
 
 /**

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.h
@@ -189,6 +189,12 @@
  */
 + (void)performEmergencyBackup;
 
+/**
+ * Get the configured harvest cycle duration in seconds
+ * @return Harvest cycle duration in seconds, or 300 if not initialized
+ */
++ (NSInteger)getHarvestCycleSeconds;
+
 @end
 
 /**

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.m
@@ -58,6 +58,28 @@ static dispatch_once_t onceToken;
     return 300; // Default value if not initialized
 }
 
++ (BOOL)isQoeAggregateEnabled {
+    if (![self isInitialized]) {
+        NRVA_ERROR_LOG(@"NRVAVideo not initialized - returning default YES");
+        return YES; // Default value if not initialized
+    }
+
+    NRVAVideo *videoInstance = [self getInstance];
+    return videoInstance.configuration.qoeAggregateEnabled;
+}
+
++ (void)setQoeAggregateEnabled:(BOOL)enabled {
+    if (![self isInitialized]) {
+        NRVA_ERROR_LOG(@"NRVAVideo not initialized - cannot set QOE aggregate");
+        return;
+    }
+
+    NRVAVideo *videoInstance = [self getInstance];
+    videoInstance.configuration.qoeAggregateEnabled = enabled;
+
+    NRVA_DEBUG_LOG(@"QOE Aggregate %@", enabled ? @"Enabled" : @"Disabled");
+}
+
 + (NRVAVideoBuilder *)newBuilder {
     return [[NRVAVideoBuilder alloc] init];
 }

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.m
@@ -27,6 +27,7 @@
 
 @interface NRVAVideo ()
 
+@property (nonatomic, strong) NRVAVideoConfiguration *configuration;
 @property (nonatomic, strong) NRVAHarvestManager *harvestManager;
 @property (nonatomic, strong) NRVAVideoLifecycleObserver *lifecycleObserver;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *trackerIds;
@@ -48,6 +49,13 @@ static dispatch_once_t onceToken;
 
 + (BOOL)isInitialized {
     return instance != nil;
+}
+
++ (NSInteger)getHarvestCycleSeconds {
+    if (instance && instance.configuration) {
+        return instance.configuration.harvestCycleSeconds;
+    }
+    return 300; // Default value if not initialized
 }
 
 + (NRVAVideoBuilder *)newBuilder {
@@ -404,6 +412,7 @@ static dispatch_once_t onceToken;
 - (instancetype)initWithConfiguration:(NRVAVideoConfiguration *)config {
     self = [super init];
     if (self) {
+        _configuration = config;
         _harvestManager = [[NRVAHarvestManager alloc] initWithConfiguration:config];
         _trackerIds = [[NSMutableDictionary alloc] init];
         _nextTrackerId = 1;

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.h
@@ -29,6 +29,13 @@
 @property (nonatomic, readonly) NSString *collectorAddress;
 
 /**
+ * QOE Aggregate toggle - thread-safe, runtime modifiable
+ * Controls whether QOE (Quality of Experience) aggregate events are collected and sent
+ * Default: YES (enabled)
+ */
+@property (atomic, assign) BOOL qoeAggregateEnabled;
+
+/**
  * Get dead letter retry interval in milliseconds
  * Optimized for different device types and network conditions
  */
@@ -62,6 +69,7 @@
 @property (nonatomic, assign) BOOL debugLoggingEnabled;
 @property (nonatomic, assign) BOOL isTV;
 @property (nonatomic, strong) NSString *collectorAddress;
+@property (nonatomic, assign) BOOL qoeAggregateEnabled;
 
 /**
  * Auto-detect platform capabilities and apply optimizations
@@ -126,6 +134,12 @@
  * If not set, will be auto-detected from application token region
  */
 - (instancetype)withCollectorAddress:(NSString *)collectorAddress;
+
+/**
+ * Enable or disable QOE (Quality of Experience) aggregate events
+ * Default: YES (enabled)
+ */
+- (instancetype)withQoeAggregateEnabled:(BOOL)qoeAggregateEnabled;
 
 /**
  * Build the configuration

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.m
@@ -61,6 +61,7 @@ static const NSInteger kMemoryOptimizedMaxOfflineStorageSizeMB = 50; // 50MB
         _debugLoggingEnabled = builder.debugLoggingEnabled;
         _isTV = builder.isTV;
         _collectorAddress = builder.collectorAddress;
+        _qoeAggregateEnabled = builder.qoeAggregateEnabled;
     }
     return self;
 }
@@ -200,6 +201,7 @@ static const NSInteger kMemoryOptimizedMaxOfflineStorageSizeMB = 50; // 50MB
 
         _debugLoggingEnabled = NO;
         _collectorAddress = nil; // Will use default based on region
+        _qoeAggregateEnabled = YES; // Default enabled
     }
     return self;
 }
@@ -304,6 +306,11 @@ static const NSInteger kMemoryOptimizedMaxOfflineStorageSizeMB = 50; // 50MB
 
 - (instancetype)withCollectorAddress:(NSString *)collectorAddress {
     self.collectorAddress = collectorAddress;
+    return self;
+}
+
+- (instancetype)withQoeAggregateEnabled:(BOOL)qoeAggregateEnabled {
+    self.qoeAggregateEnabled = qoeAggregateEnabled;
     return self;
 }
 

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVideoDefs.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVideoDefs.h
@@ -1,3 +1,4 @@
+
 //
 //  NRVideoDefs.h
 //  NextVideoAgent
@@ -28,6 +29,7 @@
 #define CONTENT_BUFFER_START        @"CONTENT_BUFFER_START"
 #define CONTENT_BUFFER_END          @"CONTENT_BUFFER_END"
 #define CONTENT_HEARTBEAT           @"CONTENT_HEARTBEAT"
+#define QOE_AGGREGATE               @"QOE_AGGREGATE"
 #define CONTENT_RENDITION_CHANGE    @"CONTENT_RENDITION_CHANGE"
 #define CONTENT_ERROR               @"CONTENT_ERROR"
 

--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.h
@@ -104,6 +104,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sendHeartbeat;
 
 /**
+ Send QoE aggregate event.
+ */
+- (void)sendQoeAggregate;
+
+/**
  Send rendition change event.
  */
 - (void)sendRenditionChange;

--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
@@ -518,6 +518,18 @@
 }
 
 - (void)sendQoeAggregate {
+    // Check if QOE aggregate is enabled - if not, skip sending
+    if (![NRVAVideo isQoeAggregateEnabled]) {
+        AV_LOG(@"QOE Aggregate disabled - skipping event");
+        return;
+    }
+
+    // Only send for content, not ads
+    if (self.state.isAd) {
+        AV_LOG(@"Skipping QOE Aggregate for ad content");
+        return;
+    }
+
     // Update bitrate tracking before sending QoE aggregate
     [self updateBitrateTracking];
 


### PR DESCRIPTION
KPIs are calculated based on this doc - https://newrelic.atlassian.net/wiki/spaces/VERTSOL/pages/4702274467/KPIs+Transformation+QOE+Score

kpi.startupTime
kpi.startupTime = timeSinceRequested
Source: TimeSince mechanism tracking time from CONTENT_REQUEST to current moment

kpi.peakBitrate
Formula: Maximum value tracking
kpi.peakBitrate = MAX(bitrate_1, bitrate_2, ..., bitrate_n)

kpi.hadStartupFailure

Formula: Boolean logic based on playback state
kpi.hadStartupFailure = (timeSinceStarted == null)

Logic:

true = Error occurred before CONTENT_START (no timeSinceStarted attribute exists)
false = Playback started successfully
kpi.hadPlaybackFailure
Formula: Boolean flag set on error during playback
kpi.hadPlaybackFailure = qoeHadPlaybackFailure

Tracking Logic:
// On CONTENT_ERROR:

kpi.totalRebufferingTime
Formula: Cumulative sum of rebuffering durations
kpi.totalRebufferingTime = Σ(rebuffer_duration_i) where buffer_type ≠ "initial"

Tracking Logic:
// On each CONTENT_BUFFER_END:

kpi.rebufferingRatio
Formula: Percentage of time spent rebuffering
double rebufferingRatio = ((double) qoeTotalRebufferingTime / totalPlaytime) * 100;

kpi.totalPlaytime
Formula: Direct attribute mapping
kpi.totalPlaytime = totalPlaytime
Source: Accumulated through updatePlaytime() mechanism

kpi.averageBitrate (NEW: Time-Weighted)
Formula: Time-weighted average of bitrates
// Primary calculation (time-weighted):
if (qoeTotalActiveTime > 0) {
kpi.averageBitrate = qoeTotalBitrateWeightedTime / qoeTotalActiveTime
}

// Fallback calculation (simple average):
else if (qoeBitrateCount > 0) {
kpi.averageBitrate = qoeBitrateSum / qoeBitrateCount
}

Time-Weighted Tracking:
// On each rendition change:
segmentDuration = currentTime - qoeLastRenditionChangeTime
qoeTotalBitrateWeightedTime += (previousBitrate × segmentDuration)
qoeTotalActiveTime += segmentDuration

// During calculation, include current segment:
currentSegmentDuration = currentTime - qoeLastRenditionChangeTime
totalWeightedTime = qoeTotalBitrateWeightedTime + (currentBitrate × currentSegmentDuration)
totalTime = qoeTotalActiveTime + currentSegmentDuration

averageBitrate = totalWeightedTime / totalTime

Mathematical Representation:
Average = Σ(bitrate_i × duration_i) / Σ(duration_i)

Where:

bitrate_i = bitrate during segment i
duration_i = time duration of segment i
i = 1 to n rendition changes

https://docs.google.com/spreadsheets/d/1nW-WDhA-cCbCKpb_EowY99d7VKGAduy9KyxlYW1elvY/edit?gid=1943942889#gid=1943942889