### PR TITLE
fix: Add obfuscation rules support

### DIFF
--- a/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAHarvestManager.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAHarvestManager.m
@@ -44,7 +44,6 @@ static NSString * const kNRVAEventTypeLive = @"live";
 @property (nonatomic, strong) id<NRVAHarvestComponentFactory> crashSafeFactory;
 @property (nonatomic, strong) NRVADefaultSizeEstimator *sizeEstimator;
 @property (nonatomic, strong) dispatch_queue_t harvestQueue;
-// Compiled obfuscation rules: each entry is @[NSRegularExpression, NSString replacement]
 @property (nonatomic, strong) NSArray<NSArray *> *compiledObfuscationRules;
 
 @end
@@ -88,7 +87,6 @@ static NSString * const kNRVAEventTypeLive = @"live";
                                                                           onDemandTask:onDemandTask
                                                                               liveTask:liveTask];
         
-        // Pre-compile obfuscation rules once so harvest doesn't pay compilation cost per-event
         NSMutableArray *compiled = [NSMutableArray array];
         for (id rule in config.obfuscationRules) {
             if (![rule isKindOfClass:[NSDictionary class]]) continue;
@@ -252,19 +250,19 @@ static NSString * const kNRVAEventTypeLive = @"live";
                 NRVA_DEBUG_LOG(@"Added %lu QoE events from active trackers", (unsigned long)qoeEvents.count);
             }
 
-            NSArray *eventsToSend = [self applyObfuscationRules:[finalEvents copy]];
+            NSArray *finalObfuscatedEvents = [self applyObfuscationRules:[finalEvents copy]];
 
-            if (eventsToSend.count > 0) {
-                [self.crashSafeFactory.getHttpClient sendEvents:eventsToSend
+            if (finalObfuscatedEvents.count > 0) {
+                [self.crashSafeFactory.getHttpClient sendEvents:finalObfuscatedEvents
                                                      harvestType:harvestType
                                                       completion:^(BOOL success) {
                     if (success) {
                         // Notify event buffer about successful harvest to trigger any pending recovery
                         [self.crashSafeFactory.getEventBuffer onSuccessfulHarvest];
                     } else {
-                        [self.crashSafeFactory.getDeadLetterHandler handleFailedEvents:eventsToSend harvestType:harvestType];
+                        [self.crashSafeFactory.getDeadLetterHandler handleFailedEvents:finalObfuscatedEvents harvestType:harvestType];
                     }
-                    NRVA_DEBUG_LOG(@"%@ harvest: %lu events", harvestType, (unsigned long)eventsToSend.count);
+                    NRVA_DEBUG_LOG(@"%@ harvest: %lu events", harvestType, (unsigned long)finalObfuscatedEvents.count);
                 }];
             }
         } @catch (NSException *exception) {

--- a/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAHarvestManager.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAHarvestManager.m
@@ -44,6 +44,8 @@ static NSString * const kNRVAEventTypeLive = @"live";
 @property (nonatomic, strong) id<NRVAHarvestComponentFactory> crashSafeFactory;
 @property (nonatomic, strong) NRVADefaultSizeEstimator *sizeEstimator;
 @property (nonatomic, strong) dispatch_queue_t harvestQueue;
+// Compiled obfuscation rules: each entry is @[NSRegularExpression, NSString replacement]
+@property (nonatomic, strong) NSArray<NSArray *> *compiledObfuscationRules;
 
 @end
 
@@ -86,8 +88,20 @@ static NSString * const kNRVAEventTypeLive = @"live";
                                                                           onDemandTask:onDemandTask
                                                                               liveTask:liveTask];
         
+        // Pre-compile obfuscation rules once so harvest doesn't pay compilation cost per-event
+        NSMutableArray *compiled = [NSMutableArray array];
+        for (id rule in config.obfuscationRules) {
+            if (![rule isKindOfClass:[NSDictionary class]]) continue;
+            NSString *pattern = rule[@"regex"];
+            NSString *replacement = rule[@"replacement"];
+            if (![pattern isKindOfClass:[NSString class]] || ![replacement isKindOfClass:[NSString class]]) continue;
+            NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:nil];
+            if (regex) [compiled addObject:@[regex, replacement]];
+        }
+        _compiledObfuscationRules = [compiled copy];
+
         NRVA_DEBUG_LOG(@"HarvestManager initialized");
-        
+
         // Log recovery status if in recovery mode
         if ([_crashSafeFactory isRecovering]) {
             NRVA_DEBUG_LOG(@"🔄 Recovery mode detected: %@", [_crashSafeFactory getRecoveryStats]);
@@ -182,6 +196,30 @@ static NSString * const kNRVAEventTypeLive = @"live";
     return [allQoeEvents copy];
 }
 
+#pragma mark - Obfuscation
+
+- (NSArray<NSDictionary<NSString *, id> *> *)applyObfuscationRules:(NSArray<NSDictionary<NSString *, id> *> *)events {
+    if (!self.compiledObfuscationRules.count) return events;
+
+    NSMutableArray *obfuscatedEvents = [NSMutableArray arrayWithCapacity:events.count];
+    for (NSDictionary<NSString *, id> *event in events) {
+        NSMutableDictionary *mutableEvent = [event mutableCopy];
+        for (NSString *key in mutableEvent.allKeys) {
+            id value = mutableEvent[key];
+            if (![value isKindOfClass:[NSString class]]) continue;
+            NSMutableString *str = [value mutableCopy];
+            for (NSArray *rule in self.compiledObfuscationRules) {
+                NSRegularExpression *regex = rule[0];
+                NSString *replacement = rule[1];
+                [regex replaceMatchesInString:str options:0 range:NSMakeRange(0, str.length) withTemplate:replacement];
+            }
+            mutableEvent[key] = [str copy];
+        }
+        [obfuscatedEvents addObject:[mutableEvent copy]];
+    }
+    return [obfuscatedEvents copy];
+}
+
 #pragma mark - Private Harvest Methods
 
 - (void)harvestNow:(NSString *)bufferType {
@@ -214,17 +252,19 @@ static NSString * const kNRVAEventTypeLive = @"live";
                 NRVA_DEBUG_LOG(@"Added %lu QoE events from active trackers", (unsigned long)qoeEvents.count);
             }
 
-            if (finalEvents.count > 0) {
-                [self.crashSafeFactory.getHttpClient sendEvents:finalEvents
+            NSArray *eventsToSend = [self applyObfuscationRules:[finalEvents copy]];
+
+            if (eventsToSend.count > 0) {
+                [self.crashSafeFactory.getHttpClient sendEvents:eventsToSend
                                                      harvestType:harvestType
                                                       completion:^(BOOL success) {
                     if (success) {
                         // Notify event buffer about successful harvest to trigger any pending recovery
                         [self.crashSafeFactory.getEventBuffer onSuccessfulHarvest];
                     } else {
-                        [self.crashSafeFactory.getDeadLetterHandler handleFailedEvents:finalEvents harvestType:harvestType];
+                        [self.crashSafeFactory.getDeadLetterHandler handleFailedEvents:eventsToSend harvestType:harvestType];
                     }
-                    NRVA_DEBUG_LOG(@"%@ harvest: %lu events", harvestType, (unsigned long)finalEvents.count);
+                    NRVA_DEBUG_LOG(@"%@ harvest: %lu events", harvestType, (unsigned long)eventsToSend.count);
                 }];
             }
         } @catch (NSException *exception) {

--- a/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAHarvestManager.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAHarvestManager.m
@@ -199,23 +199,26 @@ static NSString * const kNRVAEventTypeLive = @"live";
 - (NSArray<NSDictionary<NSString *, id> *> *)applyObfuscationRules:(NSArray<NSDictionary<NSString *, id> *> *)events {
     if (!self.compiledObfuscationRules.count) return events;
 
-    NSMutableArray *obfuscatedEvents = [NSMutableArray arrayWithCapacity:events.count];
+    NSMutableArray *result = [NSMutableArray arrayWithCapacity:events.count];
     for (NSDictionary<NSString *, id> *event in events) {
-        NSMutableDictionary *mutableEvent = [event mutableCopy];
-        for (NSString *key in mutableEvent.allKeys) {
-            id value = mutableEvent[key];
+        NSMutableDictionary *mutableEvent = nil;
+        for (NSString *key in event) {
+            id value = event[key];
             if (![value isKindOfClass:[NSString class]]) continue;
             NSMutableString *str = [value mutableCopy];
+            BOOL changed = NO;
             for (NSArray *rule in self.compiledObfuscationRules) {
-                NSRegularExpression *regex = rule[0];
-                NSString *replacement = rule[1];
-                [regex replaceMatchesInString:str options:0 range:NSMakeRange(0, str.length) withTemplate:replacement];
+                NSUInteger n = [(NSRegularExpression *)rule[0] replaceMatchesInString:str options:0 range:NSMakeRange(0, str.length) withTemplate:rule[1]];
+                if (n > 0) changed = YES;
             }
-            mutableEvent[key] = [str copy];
+            if (changed) {
+                if (!mutableEvent) mutableEvent = [event mutableCopy];
+                mutableEvent[key] = str;
+            }
         }
-        [obfuscatedEvents addObject:[mutableEvent copy]];
+        [result addObject:mutableEvent ?: event];
     }
-    return [obfuscatedEvents copy];
+    return result;
 }
 
 #pragma mark - Private Harvest Methods
@@ -250,7 +253,7 @@ static NSString * const kNRVAEventTypeLive = @"live";
                 NRVA_DEBUG_LOG(@"Added %lu QoE events from active trackers", (unsigned long)qoeEvents.count);
             }
 
-            NSArray *finalObfuscatedEvents = [self applyObfuscationRules:[finalEvents copy]];
+            NSArray *finalObfuscatedEvents = [self applyObfuscationRules:finalEvents];
 
             if (finalObfuscatedEvents.count > 0) {
                 [self.crashSafeFactory.getHttpClient sendEvents:finalObfuscatedEvents

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.h
@@ -31,6 +31,14 @@
 @property (nonatomic, readonly) NSInteger qoeAggregateIntervalMultiplier;
 
 /**
+ * Obfuscation rules applied to string attribute values before events are transmitted.
+ * Each rule is an NSDictionary with @"regex" (NSString) and @"replacement" (NSString) keys.
+ * Rules are applied in order; all rules run against every outgoing event's string attributes.
+ * Example: @{ @"regex": @"account-\\d+", @"replacement": @"ACCOUNT_ID" }
+ */
+@property (nonatomic, readonly, nullable) NSArray<NSDictionary *> *obfuscationRules;
+
+/**
  * Get dead letter retry interval in milliseconds
  * Optimized for different device types and network conditions
  */
@@ -66,6 +74,7 @@
 @property (nonatomic, strong) NSString *collectorAddress;
 @property (nonatomic, assign) BOOL qoeAggregateEnabled;
 @property (nonatomic, assign) NSInteger qoeAggregateIntervalMultiplier;
+@property (nonatomic, strong, nullable) NSArray<NSDictionary *> *obfuscationRules;
 
 /**
  * Auto-detect platform capabilities and apply optimizations
@@ -134,6 +143,16 @@
  * QoE aggregate is sent every N harvest cycles, where N is the multiplier.
  */
 - (instancetype)withQoeAggregateIntervalMultiplier:(NSInteger)multiplier;
+
+/**
+ * Set obfuscation rules to mask sensitive data in event attribute values before transmission.
+ * Rules are applied in order to every string attribute value in outgoing events.
+ * Invalid regex patterns are skipped with a warning; other rules continue to apply.
+ * Example:
+ *   @[ @{ @"regex": @"account-\\d+", @"replacement": @"ACCOUNT_ID" },
+ *      @{ @"regex": @"token=[^&\"]+", @"replacement": @"token=REDACTED" } ]
+ */
+- (instancetype)withObfuscationRules:(NSArray<NSDictionary *> *)rules;
 
 /**
  * Set custom collector domain address for /connect and /data endpoints (optional)

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.m
@@ -63,6 +63,7 @@ static const NSInteger kMemoryOptimizedMaxOfflineStorageSizeMB = 50; // 50MB
         _collectorAddress = builder.collectorAddress;
         _qoeAggregateEnabled = builder.qoeAggregateEnabled;
         _qoeAggregateIntervalMultiplier = builder.qoeAggregateIntervalMultiplier;
+        _obfuscationRules = [builder.obfuscationRules copy];
     }
     return self;
 }
@@ -204,6 +205,7 @@ static const NSInteger kMemoryOptimizedMaxOfflineStorageSizeMB = 50; // 50MB
         _collectorAddress = nil; // Will use default based on region
         _qoeAggregateEnabled = NO;
         _qoeAggregateIntervalMultiplier = 1;
+        _obfuscationRules = nil;
     }
     return self;
 }
@@ -313,6 +315,24 @@ static const NSInteger kMemoryOptimizedMaxOfflineStorageSizeMB = 50; // 50MB
 
 - (instancetype)withQoeAggregateEnabled:(BOOL)enabled {
     self.qoeAggregateEnabled = enabled;
+    return self;
+}
+
+- (instancetype)withObfuscationRules:(NSArray<NSDictionary *> *)rules {
+    for (id rule in rules) {
+        if (![rule isKindOfClass:[NSDictionary class]]) continue;
+        NSString *pattern = rule[@"regex"];
+        if (![pattern isKindOfClass:[NSString class]]) continue;
+        NSError *error = nil;
+        [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
+        if (error) {
+            @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                           reason:[NSString stringWithFormat:@"Invalid obfuscation regex '%@': %@",
+                                                   pattern, error.localizedDescription]
+                                         userInfo:nil];
+        }
+    }
+    self.obfuscationRules = rules;
     return self;
 }
 

--- a/NewRelicVideoCore/NewRelicVideoCoreTests/NRVAObfuscationRulesTests.m
+++ b/NewRelicVideoCore/NewRelicVideoCoreTests/NRVAObfuscationRulesTests.m
@@ -1,0 +1,187 @@
+//
+//  NRVAObfuscationRulesTests.m
+//  NewRelicVideoCoreTests
+//
+
+@import XCTest;
+#import "NRVAHarvestManager.h"
+#import "NRVAVideoConfiguration.h"
+
+@interface NRVAHarvestManager (ObfuscationTesting)
+- (NSArray<NSDictionary<NSString *, id> *> *)applyObfuscationRules:(NSArray<NSDictionary<NSString *, id> *> *)events;
+@property (nonatomic, strong, readonly) NSArray<NSArray *> *compiledObfuscationRules;
+@end
+
+@interface NRVAObfuscationRulesTests : XCTestCase
+@end
+
+@implementation NRVAObfuscationRulesTests
+
+- (NRVAHarvestManager *)managerWithRules:(NSArray<NSDictionary *> *)rules {
+    NRVAVideoConfiguration *config = [[[[NRVAVideoConfiguration builder]
+                                        withApplicationToken:@"test-token"]
+                                       withObfuscationRules:rules]
+                                      build];
+    return [[NRVAHarvestManager alloc] initWithConfiguration:config];
+}
+
+- (NRVAHarvestManager *)managerWithNoRules {
+    NRVAVideoConfiguration *config = [[[NRVAVideoConfiguration builder]
+                                       withApplicationToken:@"test-token"]
+                                      build];
+    return [[NRVAHarvestManager alloc] initWithConfiguration:config];
+}
+
+#pragma mark - Configuration
+
+- (void)testNoRulesCompilesEmptyList {
+    NRVAHarvestManager *manager = [self managerWithNoRules];
+    XCTAssertEqual(manager.compiledObfuscationRules.count, 0);
+}
+
+- (void)testValidRulesAreCompiled {
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @"account-\\d+", @"replacement": @"ACCOUNT_ID" },
+        @{ @"regex": @"token=[^&]+",  @"replacement": @"token=REDACTED" },
+    ]];
+    XCTAssertEqual(manager.compiledObfuscationRules.count, 2);
+}
+
+- (void)testInvalidRegexThrowsAtConfigTime {
+    XCTAssertThrowsSpecificNamed(
+        [self managerWithRules:@[ @{ @"regex": @"[invalid", @"replacement": @"X" } ]],
+        NSException,
+        NSInvalidArgumentException
+    );
+}
+
+#pragma mark - Basic Masking
+
+- (void)testMatchingValueIsReplaced {
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @"account-\\d+", @"replacement": @"ACCOUNT_ID" }
+    ]];
+    NSArray *result = [manager applyObfuscationRules:@[
+        @{ @"contentId": @"account-12345" }
+    ]];
+    XCTAssertEqualObjects(result[0][@"contentId"], @"ACCOUNT_ID");
+}
+
+- (void)testNonMatchingValueIsUnchanged {
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @"account-\\d+", @"replacement": @"ACCOUNT_ID" }
+    ]];
+    NSArray *result = [manager applyObfuscationRules:@[
+        @{ @"contentTitle": @"My Video" }
+    ]];
+    XCTAssertEqualObjects(result[0][@"contentTitle"], @"My Video");
+}
+
+- (void)testPartialMatchWithinString {
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @"\\d+", @"replacement": @"NUM" }
+    ]];
+    NSArray *result = [manager applyObfuscationRules:@[
+        @{ @"src": @"https://cdn.example.com/video/12345/manifest.m3u8" }
+    ]];
+    XCTAssertEqualObjects(result[0][@"src"], @"https://cdn.example.com/video/NUM/manifest.mNUmu");
+}
+
+- (void)testEmptyReplacementDeletesMatch {
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @"secret", @"replacement": @"" }
+    ]];
+    NSArray *result = [manager applyObfuscationRules:@[
+        @{ @"label": @"my secret value" }
+    ]];
+    XCTAssertEqualObjects(result[0][@"label"], @"my  value");
+}
+
+#pragma mark - Non-String Attributes
+
+- (void)testNumericAttributeIsUntouched {
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @"\\d+", @"replacement": @"NUM" }
+    ]];
+    NSArray *result = [manager applyObfuscationRules:@[
+        @{ @"bufferLength": @42 }
+    ]];
+    XCTAssertEqualObjects(result[0][@"bufferLength"], @42);
+}
+
+- (void)testBoolAttributeIsUntouched {
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @".", @"replacement": @"X" }
+    ]];
+    NSArray *result = [manager applyObfuscationRules:@[
+        @{ @"isLive": @YES }
+    ]];
+    XCTAssertEqualObjects(result[0][@"isLive"], @YES);
+}
+
+#pragma mark - Rule Ordering
+
+- (void)testRulesApplyInOrder {
+    // First rule turns "secret" into "HIDDEN", second rule targets "HIDDEN"
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @"secret",  @"replacement": @"HIDDEN" },
+        @{ @"regex": @"HIDDEN",  @"replacement": @"REDACTED" },
+    ]];
+    NSArray *result = [manager applyObfuscationRules:@[
+        @{ @"value": @"secret" }
+    ]];
+    XCTAssertEqualObjects(result[0][@"value"], @"REDACTED");
+}
+
+#pragma mark - Multiple Events
+
+- (void)testRulesApplyToAllEvents {
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @"token=[^&]+", @"replacement": @"token=REDACTED" }
+    ]];
+    NSArray *result = [manager applyObfuscationRules:@[
+        @{ @"src": @"https://cdn.example.com?token=abc123" },
+        @{ @"src": @"https://cdn.example.com?token=xyz789" },
+    ]];
+    XCTAssertEqualObjects(result[0][@"src"], @"https://cdn.example.com?token=REDACTED");
+    XCTAssertEqualObjects(result[1][@"src"], @"https://cdn.example.com?token=REDACTED");
+}
+
+- (void)testAllStringAttributesInEventAreScanned {
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @"pii", @"replacement": @"***" }
+    ]];
+    NSArray *result = [manager applyObfuscationRules:@[
+        @{ @"contentTitle": @"video-pii-title", @"contentId": @"pii-id-001", @"bitrate": @1500 }
+    ]];
+    XCTAssertEqualObjects(result[0][@"contentTitle"], @"video-***-title");
+    XCTAssertEqualObjects(result[0][@"contentId"],    @"***-id-001");
+    XCTAssertEqualObjects(result[0][@"bitrate"],      @1500);
+}
+
+#pragma mark - No Rules
+
+- (void)testNoRulesReturnsEventsUnmodified {
+    NRVAHarvestManager *manager = [self managerWithNoRules];
+    NSArray *events = @[ @{ @"contentSrc": @"https://cdn.example.com/video.m3u8" } ];
+    NSArray *result = [manager applyObfuscationRules:events];
+    XCTAssertEqualObjects(result, events);
+}
+
+- (void)testNoRulesReturnsIdenticalPointer {
+    // With no rules, the original array is returned as-is (no copy made)
+    NRVAHarvestManager *manager = [self managerWithNoRules];
+    NSArray *events = @[ @{ @"key": @"value" } ];
+    NSArray *result = [manager applyObfuscationRules:events];
+    XCTAssertTrue(result == events);
+}
+
+- (void)testEmptyEventsArrayReturnsEmpty {
+    NRVAHarvestManager *manager = [self managerWithRules:@[
+        @{ @"regex": @".*", @"replacement": @"X" }
+    ]];
+    NSArray *result = [manager applyObfuscationRules:@[]];
+    XCTAssertEqual(result.count, 0);
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -94,55 +94,35 @@ For complete integration examples including ad support, see the [ONBOARDING.md](
 
 ## Obfuscation Rules
 
-Video telemetry can inadvertently capture sensitive data in fields like `contentSrc`, `contentTitle`, `contentId`, and ad metadata (e.g. user IDs, account tokens, PII in URLs). Obfuscation rules let you mask this data before it is transmitted to New Relic.
+Obfuscation rules let you mask sensitive data before it is transmitted to New Relic.
 
 Each rule is a regex pattern paired with a replacement string. Rules are applied **in order** to every string attribute value in every outgoing event — including QoE events and crash-recovered events.
 
 ### Configuration
 
-<details>
-<summary>Objective-C</summary>
-<p>
-
+**Objective-C**
 ```objc
 NRVAVideoConfiguration *config = [[[[NRVAVideoConfiguration builder]
     withApplicationToken:@"YOUR_NEW_RELIC_TOKEN"]
     withObfuscationRules:@[
-        // Mask account IDs in URLs: /account-12345 → /ACCOUNT_ID
-        @{ @"regex": @"account-\\d+",       @"replacement": @"ACCOUNT_ID" },
-        // Redact auth tokens in query strings: token=abc123 → token=REDACTED
-        @{ @"regex": @"token=[^&\"]+",      @"replacement": @"token=REDACTED" },
-        // Mask user path segments: /users/john.doe → /users/USER_ID
-        @{ @"regex": @"/users/[^\"/]+",     @"replacement": @"/users/USER_ID" },
+        @{ @"regex": @"account-\\d+",  @"replacement": @"ACCOUNT_ID" },
+        @{ @"regex": @"token=[^&\"]+", @"replacement": @"token=REDACTED" },
     ]]
     build];
 [[[NRVAVideo newBuilder] withConfiguration:config] build];
 ```
 
-</p>
-</details>
-
-<details>
-<summary>Swift</summary>
-<p>
-
+**Swift**
 ```swift
 let config = NRVAVideoConfiguration.builder()
     .withApplicationToken("YOUR_NEW_RELIC_TOKEN")
     .withObfuscationRules([
-        // Mask account IDs in URLs: /account-12345 → /ACCOUNT_ID
-        ["regex": "account-\\d+",       "replacement": "ACCOUNT_ID"],
-        // Redact auth tokens in query strings: token=abc123 → token=REDACTED
-        ["regex": "token=[^&\"]+",      "replacement": "token=REDACTED"],
-        // Mask user path segments: /users/john.doe → /users/USER_ID
-        ["regex": "/users/[^\"/]+",     "replacement": "/users/USER_ID"],
+        ["regex": "account-\\d+",  "replacement": "ACCOUNT_ID"],
+        ["regex": "token=[^&\"]+", "replacement": "token=REDACTED"],
     ])
     .build()
 NRVAVideo.newBuilder().with(configuration: config).build()
 ```
-
-</p>
-</details>
 
 ### How it works
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,78 @@ let trackerId = NRVAVideo.addPlayer(playerConfig)
 
 For complete integration examples including ad support, see the [ONBOARDING.md](ONBOARDING.md) guide.
 
+## Obfuscation Rules
+
+Video telemetry can inadvertently capture sensitive data in fields like `contentSrc`, `contentTitle`, `contentId`, and ad metadata (e.g. user IDs, account tokens, PII in URLs). Obfuscation rules let you mask this data before it is transmitted to New Relic.
+
+Each rule is a regex pattern paired with a replacement string. Rules are applied **in order** to every string attribute value in every outgoing event — including QoE events and crash-recovered events.
+
+### Configuration
+
+<details>
+<summary>Objective-C</summary>
+<p>
+
+```objc
+NRVAVideoConfiguration *config = [[[[NRVAVideoConfiguration builder]
+    withApplicationToken:@"YOUR_NEW_RELIC_TOKEN"]
+    withObfuscationRules:@[
+        // Mask account IDs in URLs: /account-12345 → /ACCOUNT_ID
+        @{ @"regex": @"account-\\d+",       @"replacement": @"ACCOUNT_ID" },
+        // Redact auth tokens in query strings: token=abc123 → token=REDACTED
+        @{ @"regex": @"token=[^&\"]+",      @"replacement": @"token=REDACTED" },
+        // Mask user path segments: /users/john.doe → /users/USER_ID
+        @{ @"regex": @"/users/[^\"/]+",     @"replacement": @"/users/USER_ID" },
+    ]]
+    build];
+[[[NRVAVideo newBuilder] withConfiguration:config] build];
+```
+
+</p>
+</details>
+
+<details>
+<summary>Swift</summary>
+<p>
+
+```swift
+let config = NRVAVideoConfiguration.builder()
+    .withApplicationToken("YOUR_NEW_RELIC_TOKEN")
+    .withObfuscationRules([
+        // Mask account IDs in URLs: /account-12345 → /ACCOUNT_ID
+        ["regex": "account-\\d+",       "replacement": "ACCOUNT_ID"],
+        // Redact auth tokens in query strings: token=abc123 → token=REDACTED
+        ["regex": "token=[^&\"]+",      "replacement": "token=REDACTED"],
+        // Mask user path segments: /users/john.doe → /users/USER_ID
+        ["regex": "/users/[^\"/]+",     "replacement": "/users/USER_ID"],
+    ])
+    .build()
+NRVAVideo.newBuilder().with(configuration: config).build()
+```
+
+</p>
+</details>
+
+### How it works
+
+- Rules are applied per string attribute value, not on the raw JSON payload — numeric and boolean attributes are unaffected.
+- All rules run against every outgoing event (regular, live, QoE, and crash-recovered).
+- Rules are evaluated **in the order they are declared**. If two rules can match the same value, order matters.
+- The `applicationToken` and HTTP auth headers are never touched — obfuscation only runs on event attribute values.
+
+### Edge cases
+
+| Scenario | Behavior |
+|---|---|
+| No rules configured | No-op; zero performance overhead |
+| Empty `replacement` string | Matched content is deleted (this is intentional and allowed) |
+| Invalid regex pattern | `withObfuscationRules:` throws `NSInvalidArgumentException` at configuration time — fail fast before any events are sent |
+| Non-string attribute value (number, bool) | Skipped; only string values are processed |
+| Malformed rules array entry (not a dictionary) | Entry is skipped with a warning log |
+| `applicationToken` / auth headers | Never included in event attributes; not affected |
+| Rule ordering | Rules apply in array order — document this to your team if order matters |
+| Catastrophic backtracking | `NSRegularExpression` has no built-in timeout on iOS. Avoid patterns with unbounded quantifier nesting (e.g. `(a+)+`). Test rules against worst-case inputs before deploying. |
+
 ## Documentation
 
 To generate source code documentation, you can use [appledoc](https://github.com/tomaz/appledoc) as follows:


### PR DESCRIPTION
# Summary

* **API Expansion**: Adds `withObfuscationRules:` to `NRVAVideoConfigurationBuilder` — accepts an ordered array of regex/replacement pairs.
* **Broad Coverage**: Applies rules to every string attribute value across all outgoing events (`VideoAction`, `VideoErrorAction`, `VideoAdAction`, `VideoCustomAction`, `QoE`) before HTTP transmission.
* **Performance Optimization**: Regex patterns are compiled once at `HarvestManager` init — no per-event compilation overhead at harvest time.
* **Validation**: Invalid regex throws `NSInvalidArgumentException` at configuration time (fail fast).
* **Security Persistence**: Dead-letter retried events also receive obfuscated values — sensitive data cannot leak through retry paths.
* **Documentation**: Documents edge cases in `README`:
    * Empty replacement
    * Non-string values
    * Rule ordering
    * Catastrophic backtracking caveat