### PR TITLE
feat: add JP region support

### DIFF
--- a/NewRelicVideoCore/NewRelicVideoCore/Auth/NRVATokenManager.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Auth/NRVATokenManager.m
@@ -187,6 +187,8 @@ static const NSTimeInterval kNRVA_READ_TIMEOUT = 30.0;    // 30 seconds for TV n
         return @"https://mobile-collector.ap.newrelic.com/mobile/v5/connect";
     } else if ([region isEqualToString:@"GOV"]) {
         return @"https://gov-mobile-collector.newrelic.com/mobile/v5/connect";
+    } else if ([region isEqualToString:@"JP"]) {
+        return @"https://mobile-collector.jp.nr-data.net/mobile/v5/connect";
     } else {
         return @"https://mobile-collector.newrelic.com/mobile/v5/connect"; // US/DEFAULT
     }

--- a/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAOptimizedHttpClient.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAOptimizedHttpClient.m
@@ -273,6 +273,8 @@ static const int kMaxRetryAttempts = 3;
         return @"https://mobile-collector.ap.newrelic.com/mobile/v3/data";
     } else if ([region isEqualToString:@"GOV"]) {
         return @"https://gov-mobile-collector.newrelic.com/mobile/v3/data";
+    } else if ([region isEqualToString:@"JP"]) {
+        return @"https://mobile-collector.jp.nr-data.net/mobile/v3/data";
     } else {
         return @"https://mobile-collector.newrelic.com/mobile/v3/data"; // US/DEFAULT
     }

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.m
@@ -144,7 +144,8 @@ static const NSInteger kMemoryOptimizedMaxOfflineStorageSizeMB = 50; // 50MB
                 @"AP": @"AP",
                 @"APAC": @"AP",
                 @"GOV": @"GOV",
-                @"FED": @"GOV"
+                @"FED": @"GOV",
+                @"JP": @"JP"
             };
         });
 


### PR DESCRIPTION
Add Japan (JP) region endpoints for mobile data collector and connect API. Adds JP to regionMappings, buildEndpointUrl, and buildTokenEndpoint. Confirmed endpoints: mobile-collector.jp.nr-data.net.