### PR TITLE
fix: thread-safe NREventAttributes + AVPlayer KVO observer cleanup (4.1.2)

### DIFF
--- a/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
+++ b/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
@@ -34,6 +34,14 @@
     return self;
 }
 
+- (void)dealloc {
+    // Defensive: tear down KVO observers and NotificationCenter listeners
+    // even if the host app released the tracker without calling [dispose].
+    // unregisterListeners wraps each removeObserver: in @try/@catch, so this
+    // is safe to call multiple times (idempotent with [dispose]).
+    [self unregisterListeners];
+}
+
 - (void)setPlayer:(id)player {
     [super setPlayer:player];
     self.playerInstance = player;

--- a/NewRelicVideoCore/NewRelicVideoCore.xcodeproj/project.pbxproj
+++ b/NewRelicVideoCore/NewRelicVideoCore.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		QOETEST0001000000000002 /* NRQoEAggregatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = QOETEST0001000000000003 /* NRQoEAggregatorTests.m */; };
 		QOETEST0002000000000001 /* NRVAHarvestManagerQoETests.m in Sources */ = {isa = PBXBuildFile; fileRef = QOETEST0002000000000003 /* NRVAHarvestManagerQoETests.m */; };
 		QOETEST0002000000000002 /* NRVAHarvestManagerQoETests.m in Sources */ = {isa = PBXBuildFile; fileRef = QOETEST0002000000000003 /* NRVAHarvestManagerQoETests.m */; };
+		EATTRTS0001000000000001 /* NREventAttributesThreadSafetyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */; };
+		EATTRTS0001000000000002 /* NREventAttributesThreadSafetyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -268,6 +270,7 @@
 		B9B6605B2045E3744CF0325D /* NRTimeSinceTableThreadSafetyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRTimeSinceTableThreadSafetyTests.m; sourceTree = "<group>"; };
 		QOETEST0001000000000003 /* NRQoEAggregatorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRQoEAggregatorTests.m; sourceTree = "<group>"; };
 		QOETEST0002000000000003 /* NRVAHarvestManagerQoETests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRVAHarvestManagerQoETests.m; sourceTree = "<group>"; };
+		EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NREventAttributesThreadSafetyTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -498,6 +501,7 @@
 			isa = PBXGroup;
 			children = (
 				B9B6605B2045E3744CF0325D /* NRTimeSinceTableThreadSafetyTests.m */,
+				EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */,
 				QOETEST0001000000000003 /* NRQoEAggregatorTests.m */,
 				QOETEST0002000000000003 /* NRVAHarvestManagerQoETests.m */,
 				9CE7992825837C9400157199 /* NewRelicVideoCoreTests.m */,
@@ -792,6 +796,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				72BC6CA495AAC595919A0B84 /* NRTimeSinceTableThreadSafetyTests.m in Sources */,
+				EATTRTS0001000000000001 /* NREventAttributesThreadSafetyTests.m in Sources */,
 				QOETEST0001000000000001 /* NRQoEAggregatorTests.m in Sources */,
 				QOETEST0002000000000001 /* NRVAHarvestManagerQoETests.m in Sources */,
 				9CE7992925837C9400157199 /* NewRelicVideoCoreTests.m in Sources */,
@@ -840,6 +845,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				72BC6CA495AAC595919A0B84 /* NRTimeSinceTableThreadSafetyTests.m in Sources */,
+				EATTRTS0001000000000002 /* NREventAttributesThreadSafetyTests.m in Sources */,
 				QOETEST0001000000000002 /* NRQoEAggregatorTests.m in Sources */,
 				QOETEST0002000000000002 /* NRVAHarvestManagerQoETests.m in Sources */,
 			);

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NREventAttributes.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NREventAttributes.m
@@ -27,32 +27,45 @@
     if (!regexp) {
         regexp = @"[A-Z_]+";
     }
-    
-    // Attribute doesn't exit yet, create it
-    if (![self.attributeBuckets objectForKey:regexp]) {
-        [self.attributeBuckets setObject:@{}.mutableCopy forKey:regexp];
+
+    @synchronized (self) {
+        NSMutableDictionary *bucket = self.attributeBuckets[regexp];
+        if (!bucket) {
+            bucket = [NSMutableDictionary dictionary];
+            self.attributeBuckets[regexp] = bucket;
+        }
+        bucket[key] = value;
     }
-    
-    [[self.attributeBuckets objectForKey:regexp] setObject:value forKey:key];
 }
 
 - (NSMutableDictionary *)generateAttributes:(NSString *)action append:(nullable NSDictionary *)attributes {
-    NSMutableDictionary *attr = @{}.mutableCopy;
-    
+    NSMutableDictionary *attr = [NSMutableDictionary dictionary];
+
     if (attributes) {
         [attr addEntriesFromDictionary:attributes];
     }
-    
-    for (NSString *filter in self.attributeBuckets) {
+
+    // Snapshot the buckets under the lock so iteration is over data that cannot
+    // change underneath us. Each inner bucket is also copied because callers
+    // (and this method) iterate them.
+    NSDictionary<NSString *, NSDictionary *> *snapshot;
+    @synchronized (self) {
+        NSMutableDictionary *copy = [NSMutableDictionary dictionaryWithCapacity:self.attributeBuckets.count];
+        for (NSString *filter in self.attributeBuckets) {
+            copy[filter] = [self.attributeBuckets[filter] copy];
+        }
+        snapshot = copy;
+    }
+
+    for (NSString *filter in snapshot) {
         if ([self checkFilter:filter withAction:action]) {
-            NSMutableDictionary *bucket = self.attributeBuckets[filter];
+            NSDictionary *bucket = snapshot[filter];
             for (NSString *attribute in bucket) {
-                id<NSCoding> value = bucket[attribute];
-                [attr setObject:value forKey:attribute];
+                attr[attribute] = bucket[attribute];
             }
         }
     }
-    
+
     return attr;
 }
 

--- a/NewRelicVideoCore/NewRelicVideoCoreTests/NREventAttributesThreadSafetyTests.m
+++ b/NewRelicVideoCore/NewRelicVideoCoreTests/NREventAttributesThreadSafetyTests.m
@@ -1,0 +1,238 @@
+//
+//  NREventAttributesThreadSafetyTests.m
+//  NewRelicVideoCoreTests
+//
+//  Reproduces and prevents regression of the race condition that crashed
+//  Bell/DeltaTre's tvOS production app with:
+//    *** Collection <__NSDictionaryM> was mutated while being enumerated.
+//
+//  Stack trace had:
+//    NREventAttributes generateAttributes:append:
+//      ↑ NRVideoTracker getAttributes:attributes:
+//      ↑ NRTrackerAVPlayer sendBufferStart
+//      ↑ NRTrackerAVPlayer observeValueForKeyPath:ofObject:change:context:
+//
+//  Root cause: setAttribute: mutated NREventAttributes.attributeBuckets while
+//  generateAttributes: enumerated it on another thread (AVPlayer KVO thread,
+//  heartbeat timer, harvest queue).
+//
+
+@import XCTest;
+#import "NREventAttributes.h"
+
+@interface NREventAttributesThreadSafetyTests : XCTestCase
+
+@property (nonatomic) NREventAttributes *eventAttributes;
+
+@end
+
+@implementation NREventAttributesThreadSafetyTests
+
+- (void)setUp {
+    [super setUp];
+    self.eventAttributes = [[NREventAttributes alloc] init];
+}
+
+- (void)tearDown {
+    self.eventAttributes = nil;
+    [super tearDown];
+}
+
+#pragma mark - Concurrent access tests
+
+/// Many threads reading at the same time. No mutation. Should never crash.
+- (void)testConcurrentReads {
+    NSLog(@"🧪 Testing concurrent reads...");
+
+    for (int i = 0; i < 10; i++) {
+        [self.eventAttributes setAttribute:[NSString stringWithFormat:@"key_%d", i]
+                                     value:@(i)
+                                    filter:nil];
+    }
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Concurrent reads complete"];
+    expectation.expectedFulfillmentCount = 200;
+
+    for (int i = 0; i < 200; i++) {
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            NSMutableDictionary *out = [self.eventAttributes generateAttributes:@"ANY_ACTION" append:nil];
+            XCTAssertEqual(out.count, (NSUInteger)10);
+            [expectation fulfill];
+        });
+    }
+
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
+        XCTAssertNil(error);
+        NSLog(@"✅ Concurrent reads passed");
+    }];
+}
+
+/// Many threads writing simultaneously. Should never crash and the final
+/// dictionary should be in a coherent state.
+- (void)testConcurrentWrites {
+    NSLog(@"🧪 Testing concurrent writes...");
+
+    NSInteger writerCount = 8;
+    NSInteger writesPerWorker = 1000;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Concurrent writes complete"];
+    expectation.expectedFulfillmentCount = (NSUInteger)writerCount;
+
+    for (NSInteger w = 0; w < writerCount; w++) {
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            for (NSInteger i = 0; i < writesPerWorker; i++) {
+                [self.eventAttributes setAttribute:[NSString stringWithFormat:@"w%ld_k%ld", (long)w, (long)i]
+                                             value:@(i)
+                                            filter:nil];
+            }
+            [expectation fulfill];
+        });
+    }
+
+    [self waitForExpectationsWithTimeout:30.0 handler:^(NSError *error) {
+        XCTAssertNil(error, @"Concurrent writes hung or crashed: %@", error);
+    }];
+
+    NSMutableDictionary *out = [self.eventAttributes generateAttributes:@"ANY_ACTION" append:nil];
+    XCTAssertEqual(out.count, (NSUInteger)(writerCount * writesPerWorker));
+    NSLog(@"✅ Concurrent writes passed (%lu keys)", (unsigned long)out.count);
+}
+
+/// THE CRITICAL TEST: concurrent readers + writers, mirroring the production
+/// scenario. With the un-synchronized version of NREventAttributes this crashes
+/// within ~1 second. With @synchronized + snapshot it runs to completion.
+- (void)testConcurrentReadsAndWritesMirrorsProductionRace {
+    NSLog(@"🧪 Testing concurrent reads + writes (production race repro)...");
+
+    NSInteger writerCount = 4;
+    NSInteger readerCount = 4;
+    NSTimeInterval durationSeconds = 2.0;
+
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:durationSeconds];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Concurrent r/w complete"];
+    expectation.expectedFulfillmentCount = (NSUInteger)(writerCount + readerCount);
+
+    // Writers — keep mutating attributeBuckets until the deadline.
+    for (NSInteger w = 0; w < writerCount; w++) {
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            NSInteger i = 0;
+            while ([deadline timeIntervalSinceNow] > 0) {
+                [self.eventAttributes setAttribute:[NSString stringWithFormat:@"writer_%ld_key_%ld", (long)w, (long)(i % 50)]
+                                             value:@(i)
+                                            filter:nil];
+                i++;
+            }
+            [expectation fulfill];
+        });
+    }
+
+    // Readers — keep enumerating attributeBuckets until the deadline.
+    // generateAttributes:append: is the exact code path the production crash hit.
+    for (NSInteger r = 0; r < readerCount; r++) {
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            while ([deadline timeIntervalSinceNow] > 0) {
+                [self.eventAttributes generateAttributes:@"CONTENT_BUFFER_START" append:nil];
+            }
+            [expectation fulfill];
+        });
+    }
+
+    [self waitForExpectationsWithTimeout:durationSeconds + 5.0 handler:^(NSError *error) {
+        XCTAssertNil(error, @"Race test hung or crashed: %@", error);
+    }];
+
+    NSLog(@"✅ Concurrent r/w passed — no mid-enumeration mutation");
+}
+
+/// Multiple filter buckets, concurrent access. Verifies that adding new bucket
+/// keys (not just overwriting existing ones) is also safe — that's the case
+/// that most reliably trips Cocoa's mutation guard.
+- (void)testConcurrentFilterBucketAdditions {
+    NSLog(@"🧪 Testing concurrent filter bucket additions...");
+
+    NSInteger workerCount = 8;
+    NSInteger filtersPerWorker = 200;
+    NSTimeInterval testDuration = 1.5;
+
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:testDuration];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Bucket additions complete"];
+    expectation.expectedFulfillmentCount = (NSUInteger)workerCount;
+
+    // Half writers (each on its own filter pattern → growing bucket map),
+    // half readers (enumerating the filter map).
+    for (NSInteger w = 0; w < workerCount / 2; w++) {
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            for (NSInteger i = 0; i < filtersPerWorker; i++) {
+                NSString *uniqueFilter = [NSString stringWithFormat:@"FILTER_%ld_%ld", (long)w, (long)i];
+                [self.eventAttributes setAttribute:@"key" value:@(i) filter:uniqueFilter];
+            }
+            [expectation fulfill];
+        });
+    }
+    for (NSInteger r = 0; r < workerCount / 2; r++) {
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            while ([deadline timeIntervalSinceNow] > 0) {
+                [self.eventAttributes generateAttributes:@"FILTER_0_0" append:nil];
+            }
+            [expectation fulfill];
+        });
+    }
+
+    [self waitForExpectationsWithTimeout:testDuration + 5.0 handler:^(NSError *error) {
+        XCTAssertNil(error, @"Bucket addition test hung or crashed: %@", error);
+    }];
+
+    NSLog(@"✅ Concurrent filter bucket additions passed");
+}
+
+#pragma mark - Correctness tests
+
+/// After concurrent writes settle, every key should be readable with its last value.
+- (void)testWritesAreReadableAfterConcurrentLoad {
+    NSLog(@"🧪 Testing writes survive concurrent load...");
+
+    NSInteger workers = 4;
+    NSInteger writesPerWorker = 500;
+
+    dispatch_group_t group = dispatch_group_create();
+    for (NSInteger w = 0; w < workers; w++) {
+        dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            for (NSInteger i = 0; i < writesPerWorker; i++) {
+                [self.eventAttributes setAttribute:[NSString stringWithFormat:@"key_%ld", (long)i]
+                                             value:@(w * 10000 + i)
+                                            filter:nil];
+            }
+        });
+    }
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+
+    NSMutableDictionary *out = [self.eventAttributes generateAttributes:@"ANY" append:nil];
+    XCTAssertEqual(out.count, (NSUInteger)writesPerWorker, @"All keys should be present after writes");
+    NSLog(@"✅ %lu keys survived concurrent writes", (unsigned long)out.count);
+}
+
+/// generateAttributes: must include both the appended dictionary and the bucket attributes.
+- (void)testAppendedAttributesIncludedInResult {
+    [self.eventAttributes setAttribute:@"trackerKey" value:@"trackerValue" filter:nil];
+
+    NSMutableDictionary *out = [self.eventAttributes generateAttributes:@"ACTION"
+                                                                 append:@{@"appendedKey": @"appendedValue"}];
+
+    XCTAssertEqualObjects(out[@"trackerKey"], @"trackerValue");
+    XCTAssertEqualObjects(out[@"appendedKey"], @"appendedValue");
+}
+
+/// Filter expressions must still be honored after the thread-safety changes.
+- (void)testFilterExpressionStillFiltersBucket {
+    [self.eventAttributes setAttribute:@"contentKey" value:@"v1" filter:@"CONTENT_.*"];
+    [self.eventAttributes setAttribute:@"adKey" value:@"v2" filter:@"AD_.*"];
+
+    NSMutableDictionary *contentOut = [self.eventAttributes generateAttributes:@"CONTENT_START" append:nil];
+    XCTAssertEqualObjects(contentOut[@"contentKey"], @"v1");
+    XCTAssertNil(contentOut[@"adKey"], @"adKey should be filtered out for CONTENT_ events");
+
+    NSMutableDictionary *adOut = [self.eventAttributes generateAttributes:@"AD_START" append:nil];
+    XCTAssertEqualObjects(adOut[@"adKey"], @"v2");
+    XCTAssertNil(adOut[@"contentKey"], @"contentKey should be filtered out for AD_ events");
+}
+
+@end


### PR DESCRIPTION
## Summary

Two targeted fixes for the production tvOS crash reported by Bell / DeltaTre on the TSN app. Already shipped to the customer as `v4.1.2-rc.1` and validated.

- **`NREventAttributes` thread-safety** — `attributeBuckets` was a shared `NSMutableDictionary` mutated by `setAttribute:` while concurrently iterated by `generateAttributes:` on different threads (AVPlayer KVO callbacks, heartbeat timer, harvest queue, host-app `setAttribute:` from Combine/async-await). Iteration tripped the fast-enumeration mutation guard, throwing `NSGenericException: *** Collection <__NSDictionaryM> was mutated while being enumerated`. Wraps mutations in `@synchronized(self)` and snapshots the bucket map under the lock before iterating, so iteration is over an immutable view. Reads and writes from any thread are now safe.
- **`NRTrackerAVPlayer` defensive `dealloc`** — KVO observers, the periodic time observer, and `NSNotificationCenter` listeners were torn down only when the host app explicitly called `[dispose]`. Adding a `dealloc` that calls `unregisterListeners` is idempotent with `[dispose]` and prevents observer-cleanup crashes when the host's teardown order is unusual (common in modern SwiftUI / Combine apps).

## Test coverage

`NREventAttributesThreadSafetyTests` (7 tests) — covers concurrent reads, concurrent writes, the production race scenario (4 writers + 4 readers for 2s mirroring the customer's traffic), filter-bucket additions under contention, and correctness invariants. All pass on iOS Simulator.

## Validation

- Reproduced the crash on `Examples/iOS/SimplePlayerUsingPods` with a stress harness mirroring Bell's runtime usage of `setAttribute:` from background threads.
- Same harness runs cleanly with this fix applied — both with QoE enabled and disabled.
- Customer's production crash log frames matched line-for-line: `NREventAttributes generateAttributes:append:` ← `NRTracker getAttributes:` ← `NRVideoTracker sendBufferStart` ← `NRTrackerAVPlayer observeValueForKeyPath:`.
- `v4.1.2-rc.1` tagged on this branch and provided to the customer for validation.

## Test plan

- [x] iOS Simulator unit tests green
- [x] Stress harness in sample app crashes pre-fix, runs clean post-fix
- [x] Customer pulled `v4.1.2-rc.1` via `:git + :tag` and is validating in their build

## Out of scope

A broader audit during validation surfaced additional pre-existing bugs (NSNull leak in `NewRelicVideoAgent.setUserId:` / `setGlobalAttribute:`, missing JSON sanitization at the `setAttribute:` boundary, broken QoE harvest tests, no shared tvOS test scheme). Those land in **4.1.3** via `fix/tracker-safety-followups`.