### PR TITLE
docs: fix CocoaPods install name in README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Download the latest pre-built XCFrameworks from the [Releases](https://github.co
 Add the dependencies to your `Podfile`:
 
 ```ruby
-pod 'NewRelicVideoCore'
+pod 'NewRelicVideoAgent'
 pod 'NRAVPlayerTracker'
 pod 'NRIMATracker'   # Optional — only if using Google IMA ads
 ```


### PR DESCRIPTION
## Summary
- README's CocoaPods install snippet listed `pod 'NewRelicVideoCore'`, which is not a New Relic-published pod
- Correct pod is `pod 'NewRelicVideoAgent'` (NewRelicVideoCore is only the internal `module_name` for framework-import backward-compat)
- INSTALLATION.md already shows the correct name; this aligns the README

## Merge note
Please retain `[skip ci]` in the squash-merge commit message so the Version Bump PR workflow does not fire on this docs-only change.

## Test plan
- [x] Verified diff is limited to `README.md`, single line change
- [x] Reviewer confirms `pod 'NewRelicVideoAgent'` matches the published pod on `trunk.cocoapods.org`