### PR TITLE
fix: NRTrackerPair NSNull leak and attribute value sanitization

### DIFF
--- a/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
+++ b/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
@@ -22,6 +22,9 @@
 @property (nonatomic) float lastRenditionWidth;
 @property (nonatomic) Float64 lastTrackerTimeEvent;
 @property (nonatomic) NSString *renditionChangeShift;
+// Seek auto-detection: track expected vs actual playhead position each 0.5s tick
+@property (nonatomic) Float64 lastKnownTime;       // playhead at last tick
+@property (nonatomic) Float64 lastKnownRate;       // rate at last tick
 
 @end
 
@@ -278,6 +281,12 @@
     else if ([keyPath isEqualToString:@"timeControlStatus"]) {
         if (@available(iOS 10.0, *)) {
             if (self.playerInstance.timeControlStatus == AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate) {
+                // If content has already started, WaitingToPlayAtSpecifiedRate means the user
+                // initiated a seek — auto-signal seek start so integrators using AVPlayerViewController
+                // don't need to call sendSeekStart: manually.
+                if (self.state.isStarted && !self.state.isSeeking) {
+                    [self.state startSeekingEvent];
+                }
                 [self sendBufferStart];
             }
             else {

--- a/NewRelicVideoCore/NewRelicVideoCore.xcodeproj/project.pbxproj
+++ b/NewRelicVideoCore/NewRelicVideoCore.xcodeproj/project.pbxproj
@@ -155,6 +155,8 @@
 		QOETEST0002000000000002 /* NRVAHarvestManagerQoETests.m in Sources */ = {isa = PBXBuildFile; fileRef = QOETEST0002000000000003 /* NRVAHarvestManagerQoETests.m */; };
 		EATTRTS0001000000000001 /* NREventAttributesThreadSafetyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */; };
 		EATTRTS0001000000000002 /* NREventAttributesThreadSafetyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */; };
+		PAIRTST0001000000000001 /* NRTrackerPairTests.m in Sources */ = {isa = PBXBuildFile; fileRef = PAIRTST0001000000000003 /* NRTrackerPairTests.m */; };
+		PAIRTST0001000000000002 /* NRTrackerPairTests.m in Sources */ = {isa = PBXBuildFile; fileRef = PAIRTST0001000000000003 /* NRTrackerPairTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -271,6 +273,7 @@
 		QOETEST0001000000000003 /* NRQoEAggregatorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRQoEAggregatorTests.m; sourceTree = "<group>"; };
 		QOETEST0002000000000003 /* NRVAHarvestManagerQoETests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRVAHarvestManagerQoETests.m; sourceTree = "<group>"; };
 		EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NREventAttributesThreadSafetyTests.m; sourceTree = "<group>"; };
+		PAIRTST0001000000000003 /* NRTrackerPairTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRTrackerPairTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -502,6 +505,7 @@
 			children = (
 				B9B6605B2045E3744CF0325D /* NRTimeSinceTableThreadSafetyTests.m */,
 				EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */,
+				PAIRTST0001000000000003 /* NRTrackerPairTests.m */,
 				QOETEST0001000000000003 /* NRQoEAggregatorTests.m */,
 				QOETEST0002000000000003 /* NRVAHarvestManagerQoETests.m */,
 				9CE7992825837C9400157199 /* NewRelicVideoCoreTests.m */,
@@ -797,6 +801,7 @@
 			files = (
 				72BC6CA495AAC595919A0B84 /* NRTimeSinceTableThreadSafetyTests.m in Sources */,
 				EATTRTS0001000000000001 /* NREventAttributesThreadSafetyTests.m in Sources */,
+				PAIRTST0001000000000001 /* NRTrackerPairTests.m in Sources */,
 				QOETEST0001000000000001 /* NRQoEAggregatorTests.m in Sources */,
 				QOETEST0002000000000001 /* NRVAHarvestManagerQoETests.m in Sources */,
 				9CE7992925837C9400157199 /* NewRelicVideoCoreTests.m in Sources */,
@@ -846,6 +851,7 @@
 			files = (
 				72BC6CA495AAC595919A0B84 /* NRTimeSinceTableThreadSafetyTests.m in Sources */,
 				EATTRTS0001000000000002 /* NREventAttributesThreadSafetyTests.m in Sources */,
+				PAIRTST0001000000000002 /* NRTrackerPairTests.m in Sources */,
 				QOETEST0001000000000002 /* NRQoEAggregatorTests.m in Sources */,
 				QOETEST0002000000000002 /* NRVAHarvestManagerQoETests.m in Sources */,
 			);

--- a/NewRelicVideoCore/NewRelicVideoCore.xcodeproj/project.pbxproj
+++ b/NewRelicVideoCore/NewRelicVideoCore.xcodeproj/project.pbxproj
@@ -157,6 +157,8 @@
 		EATTRTS0001000000000002 /* NREventAttributesThreadSafetyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */; };
 		PAIRTST0001000000000001 /* NRTrackerPairTests.m in Sources */ = {isa = PBXBuildFile; fileRef = PAIRTST0001000000000003 /* NRTrackerPairTests.m */; };
 		PAIRTST0001000000000002 /* NRTrackerPairTests.m in Sources */ = {isa = PBXBuildFile; fileRef = PAIRTST0001000000000003 /* NRTrackerPairTests.m */; };
+		VLDSAN0001000000000001 /* NREventAttributesValueSanitizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = VLDSAN0001000000000003 /* NREventAttributesValueSanitizationTests.m */; };
+		VLDSAN0001000000000002 /* NREventAttributesValueSanitizationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = VLDSAN0001000000000003 /* NREventAttributesValueSanitizationTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -274,6 +276,7 @@
 		QOETEST0002000000000003 /* NRVAHarvestManagerQoETests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRVAHarvestManagerQoETests.m; sourceTree = "<group>"; };
 		EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NREventAttributesThreadSafetyTests.m; sourceTree = "<group>"; };
 		PAIRTST0001000000000003 /* NRTrackerPairTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRTrackerPairTests.m; sourceTree = "<group>"; };
+		VLDSAN0001000000000003 /* NREventAttributesValueSanitizationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NREventAttributesValueSanitizationTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -506,6 +509,7 @@
 				B9B6605B2045E3744CF0325D /* NRTimeSinceTableThreadSafetyTests.m */,
 				EATTRTS0001000000000003 /* NREventAttributesThreadSafetyTests.m */,
 				PAIRTST0001000000000003 /* NRTrackerPairTests.m */,
+				VLDSAN0001000000000003 /* NREventAttributesValueSanitizationTests.m */,
 				QOETEST0001000000000003 /* NRQoEAggregatorTests.m */,
 				QOETEST0002000000000003 /* NRVAHarvestManagerQoETests.m */,
 				9CE7992825837C9400157199 /* NewRelicVideoCoreTests.m */,
@@ -802,6 +806,7 @@
 				72BC6CA495AAC595919A0B84 /* NRTimeSinceTableThreadSafetyTests.m in Sources */,
 				EATTRTS0001000000000001 /* NREventAttributesThreadSafetyTests.m in Sources */,
 				PAIRTST0001000000000001 /* NRTrackerPairTests.m in Sources */,
+				VLDSAN0001000000000001 /* NREventAttributesValueSanitizationTests.m in Sources */,
 				QOETEST0001000000000001 /* NRQoEAggregatorTests.m in Sources */,
 				QOETEST0002000000000001 /* NRVAHarvestManagerQoETests.m in Sources */,
 				9CE7992925837C9400157199 /* NewRelicVideoCoreTests.m in Sources */,
@@ -852,6 +857,7 @@
 				72BC6CA495AAC595919A0B84 /* NRTimeSinceTableThreadSafetyTests.m in Sources */,
 				EATTRTS0001000000000002 /* NREventAttributesThreadSafetyTests.m in Sources */,
 				PAIRTST0001000000000002 /* NRTrackerPairTests.m in Sources */,
+				VLDSAN0001000000000002 /* NREventAttributesValueSanitizationTests.m in Sources */,
 				QOETEST0001000000000002 /* NRQoEAggregatorTests.m in Sources */,
 				QOETEST0002000000000002 /* NRVAHarvestManagerQoETests.m in Sources */,
 			);

--- a/NewRelicVideoCore/NewRelicVideoCore.xcodeproj/xcshareddata/xcschemes/tvOS NewRelicVideoCore.xcscheme
+++ b/NewRelicVideoCore/NewRelicVideoCore.xcodeproj/xcshareddata/xcschemes/tvOS NewRelicVideoCore.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1210"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9CE7993A25837D0A00157199"
+               BuildableName = "NewRelicVideoCore.framework"
+               BlueprintName = "tvOS NewRelicVideoCore"
+               ReferencedContainer = "container:NewRelicVideoCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9CE7994225837D0B00157199"
+               BuildableName = "NewRelicVideoCore-tvOS.xctest"
+               BlueprintName = "tvOS NewRelicVideoCoreTests"
+               ReferencedContainer = "container:NewRelicVideoCore.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9CE7993A25837D0A00157199"
+            BuildableName = "NewRelicVideoCore.framework"
+            BlueprintName = "tvOS NewRelicVideoCore"
+            ReferencedContainer = "container:NewRelicVideoCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NREventAttributes.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NREventAttributes.m
@@ -6,6 +6,7 @@
 //
 
 #import "NREventAttributes.h"
+#import "NRVALog.h"
 
 @interface NREventAttributes ()
 
@@ -22,10 +23,60 @@
     return self;
 }
 
+// Convert any value the caller passed into something the harvest pipeline can
+// safely serialize via NSJSONSerialization. Returns nil for values that can't
+// be made JSON-safe — caller drops them with a log instead of letting the
+// async harvest crash deep inside the dispatch queue with no link to source.
+//
+//   NSString / NSNumber / NSNull → passed through
+//   NSDate                       → epoch-seconds NSNumber
+//   NSArray / NSDictionary       → recursively sanitized; nil if any element
+//                                  is unsanitizable
+//   anything else                → nil (caller logs and drops)
+- (nullable id)sanitizedValueForJSON:(id)value {
+    if (value == nil || value == [NSNull null]) {
+        return value;
+    }
+    if ([value isKindOfClass:[NSString class]] || [value isKindOfClass:[NSNumber class]]) {
+        return value;
+    }
+    if ([value isKindOfClass:[NSDate class]]) {
+        return @([(NSDate *)value timeIntervalSince1970]);
+    }
+    if ([value isKindOfClass:[NSArray class]]) {
+        NSMutableArray *cleaned = [NSMutableArray arrayWithCapacity:[(NSArray *)value count]];
+        for (id element in (NSArray *)value) {
+            id clean = [self sanitizedValueForJSON:element];
+            if (clean == nil) return nil;
+            [cleaned addObject:clean];
+        }
+        return cleaned;
+    }
+    if ([value isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *src = (NSDictionary *)value;
+        NSMutableDictionary *cleaned = [NSMutableDictionary dictionaryWithCapacity:src.count];
+        for (id k in src) {
+            if (![k isKindOfClass:[NSString class]]) return nil;
+            id clean = [self sanitizedValueForJSON:src[k]];
+            if (clean == nil) return nil;
+            cleaned[k] = clean;
+        }
+        return cleaned;
+    }
+    return nil;
+}
+
 - (void)setAttribute:(NSString *)key value:(id<NSCopying>)value filter:(nullable NSString *)regexp {
     // If no filter defined, use universal filter that matches any action name
     if (!regexp) {
         regexp = @"[A-Z_]+";
+    }
+
+    id sanitized = [self sanitizedValueForJSON:value];
+    if (sanitized == nil) {
+        NRVA_ERROR_LOG(@"setAttribute dropped key '%@' — value of type %@ is not JSON-safe (only NSString, NSNumber, NSDate, NSNull, NSArray, NSDictionary are accepted; nested containers are sanitized recursively).",
+                       key, NSStringFromClass([(NSObject *)value class]));
+        return;
     }
 
     @synchronized (self) {
@@ -34,7 +85,7 @@
             bucket = [NSMutableDictionary dictionary];
             self.attributeBuckets[regexp] = bucket;
         }
-        bucket[key] = value;
+        bucket[key] = sanitized;
     }
 }
 

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NREventAttributes.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NREventAttributes.m
@@ -25,13 +25,16 @@
 
 // Convert any value the caller passed into something the harvest pipeline can
 // safely serialize via NSJSONSerialization. Returns nil for values that can't
-// be made JSON-safe — caller drops them with a log instead of letting the
+// be made JSON-safe — caller logs and drops them instead of letting the
 // async harvest crash deep inside the dispatch queue with no link to source.
 //
 //   NSString / NSNumber / NSNull → passed through
 //   NSDate                       → epoch-seconds NSNumber
-//   NSArray / NSDictionary       → recursively sanitized; nil if any element
-//                                  is unsanitizable
+//   NSArray                      → recursively sanitized; unsanitizable elements
+//                                  are dropped (logged) and the rest are kept
+//   NSDictionary                 → recursively sanitized; entries with a
+//                                  non-string key or unsanitizable value are
+//                                  dropped (logged) and the rest are kept
 //   anything else                → nil (caller logs and drops)
 - (nullable id)sanitizedValueForJSON:(id)value {
     if (value == nil || value == [NSNull null]) {
@@ -47,7 +50,11 @@
         NSMutableArray *cleaned = [NSMutableArray arrayWithCapacity:[(NSArray *)value count]];
         for (id element in (NSArray *)value) {
             id clean = [self sanitizedValueForJSON:element];
-            if (clean == nil) return nil;
+            if (clean == nil) {
+                NRVA_ERROR_LOG(@"sanitizedValueForJSON: dropped array element of type %@ — not JSON-safe.",
+                               NSStringFromClass([element class]));
+                continue;
+            }
             [cleaned addObject:clean];
         }
         return cleaned;
@@ -56,9 +63,17 @@
         NSDictionary *src = (NSDictionary *)value;
         NSMutableDictionary *cleaned = [NSMutableDictionary dictionaryWithCapacity:src.count];
         for (id k in src) {
-            if (![k isKindOfClass:[NSString class]]) return nil;
+            if (![k isKindOfClass:[NSString class]]) {
+                NRVA_ERROR_LOG(@"sanitizedValueForJSON: dropped dictionary entry — key of type %@ is not a string.",
+                               NSStringFromClass([k class]));
+                continue;
+            }
             id clean = [self sanitizedValueForJSON:src[k]];
-            if (clean == nil) return nil;
+            if (clean == nil) {
+                NRVA_ERROR_LOG(@"sanitizedValueForJSON: dropped dictionary key '%@' — value of type %@ is not JSON-safe.",
+                               k, NSStringFromClass([src[k] class]));
+                continue;
+            }
             cleaned[k] = clean;
         }
         return cleaned;
@@ -72,10 +87,15 @@
         regexp = @"[A-Z_]+";
     }
 
+    // Silently drop nil — no error, nothing to store.
+    if (value == nil) {
+        return;
+    }
+
     id sanitized = [self sanitizedValueForJSON:value];
     if (sanitized == nil) {
         NRVA_ERROR_LOG(@"setAttribute dropped key '%@' — value of type %@ is not JSON-safe (only NSString, NSNumber, NSDate, NSNull, NSArray, NSDictionary are accepted; nested containers are sanitized recursively).",
-                       key, NSStringFromClass([(NSObject *)value class]));
+                       key, NSStringFromClass([(id)value class]));
         return;
     }
 

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
@@ -234,6 +234,10 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
     //   Includes ad buffer, seek, and pause — not just ad playing time.
     NSNumber *timeSinceRequested = attributes[@"timeSinceRequested"];
     if (timeSinceRequested) {
+        NSNumber *preRollAdTime = attributes[@"totalPreRollAdTime"];
+        if (preRollAdTime) {
+            _totalPreRollAdTime = [preRollAdTime longValue];
+        }
         long startup = [timeSinceRequested longValue] - _totalPreRollAdTime;
         self.startupTime = @(MAX(startup, 0));
     }

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
@@ -216,10 +216,6 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
 }
 
 - (void)setTotalPreRollAdTime:(long)preRollAdTime {
-    if (!self) {
-        NSLog(@"ERROR: setTotalPreRollAdTime called on nil aggregator");
-        return;
-    }
     @synchronized (self) {
         _totalPreRollAdTime = preRollAdTime;
     }
@@ -234,10 +230,6 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
     //   Includes ad buffer, seek, and pause — not just ad playing time.
     NSNumber *timeSinceRequested = attributes[@"timeSinceRequested"];
     if (timeSinceRequested) {
-        NSNumber *preRollAdTime = attributes[@"totalPreRollAdTime"];
-        if (preRollAdTime) {
-            _totalPreRollAdTime = [preRollAdTime longValue];
-        }
         long startup = [timeSinceRequested longValue] - _totalPreRollAdTime;
         self.startupTime = @(MAX(startup, 0));
     }

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerPair.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerPair.h
@@ -26,18 +26,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithFirst:(nullable NRTracker *)first second:(nullable NRTracker *)second;
 
 /**
- Get first tracker.
- 
- @return First tracker.
+ Get first tracker, or nil if none was provided at init time.
+
+ @return First tracker, or nil.
  */
-- (NRTracker *)first;
+- (nullable NRTracker *)first;
 
 /**
- Get second tracker.
- 
- @return Second tracker.
+ Get second tracker, or nil if none was provided at init time.
+
+ @return Second tracker, or nil.
  */
-- (NRTracker *)second;
+- (nullable NRTracker *)second;
 
 @end
 

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerPair.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRTrackerPair.m
@@ -16,6 +16,9 @@
 
 @implementation NRTrackerPair
 
+// NSArray cannot hold nil, so a missing tracker is stored internally as NSNull.
+// That sentinel is an implementation detail — `first` and `second` translate
+// it back to nil so callers always see nil-or-tracker, never NSNull.
 - (instancetype)initWithFirst:(nullable NRTracker *)first second:(nullable NRTracker *)second {
     if (self = [super init]) {
         if (first == nil) {
@@ -29,12 +32,14 @@
     return self;
 }
 
-- (NRTracker *)first {
-    return self.pair[0];
+- (nullable NRTracker *)first {
+    id value = self.pair[0];
+    return value == [NSNull null] ? nil : value;
 }
 
-- (NRTracker *)second {
-    return self.pair[1];
+- (nullable NRTracker *)second {
+    id value = self.pair[1];
+    return value == [NSNull null] ? nil : value;
 }
 
 @end

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.h
@@ -194,6 +194,23 @@
  */
 + (BOOL)isQoeAggregateEnabled;
 
+/**
+ * Signal that the user started seeking on the content tracker.
+ * Call this when your UI's scrubber begins dragging.
+ * AVPlayer integrations using NRTrackerAVPlayer detect this automatically —
+ * only needed for custom player integrations.
+ * @param trackerId The tracker ID returned by addPlayer:
+ */
++ (void)sendSeekStart:(NSInteger)trackerId;
+
+/**
+ * Signal that the user finished seeking on the content tracker.
+ * Call this when your UI's scrubber is released.
+ * AVPlayer integrations using NRTrackerAVPlayer detect this automatically —
+ * only needed for custom player integrations.
+ * @param trackerId The tracker ID returned by addPlayer:
+ */
++ (void)sendSeekEnd:(NSInteger)trackerId;
 
 @end
 

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideo.m
@@ -15,6 +15,7 @@
 #import "NRVAUtils.h"
 #import "NewRelicVideoAgent.h"
 #import "Tracker/NRTracker.h"
+#import "Tracker/NRVideoTracker.h"
 #import <AVFoundation/AVFoundation.h>
 
 // Import IMA types for the convenience methods
@@ -345,7 +346,23 @@ static dispatch_once_t onceToken;
     return [self getInstance].configuration.qoeAggregateEnabled;
 }
 
++ (void)sendSeekStart:(NSInteger)trackerId {
+    if (![self isInitialized]) return;
+    NRVideoTracker *tracker = (NRVideoTracker *)[[NewRelicVideoAgent sharedInstance] contentTracker:@(trackerId)];
+    if (tracker) {
+        [tracker sendSeekStart];
+        NRVA_DEBUG_LOG(@"sendSeekStart called for tracker %ld", (long)trackerId);
+    }
+}
 
++ (void)sendSeekEnd:(NSInteger)trackerId {
+    if (![self isInitialized]) return;
+    NRVideoTracker *tracker = (NRVideoTracker *)[[NewRelicVideoAgent sharedInstance] contentTracker:@(trackerId)];
+    if (tracker) {
+        [tracker sendSeekEnd];
+        NRVA_DEBUG_LOG(@"sendSeekEnd called for tracker %ld", (long)trackerId);
+    }
+}
 
 #pragma mark - Internal Methods (Package Private)
 

--- a/NewRelicVideoCore/NewRelicVideoCore/NewRelicVideoAgent.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/NewRelicVideoAgent.m
@@ -86,23 +86,11 @@
 }
 
 - (nullable NRTracker *)contentTracker:(NSNumber *)trackerId {
-    NRTrackerPair *pair = [self.trackerPairs objectForKey:trackerId];
-    if ([[pair first] isEqual:[NSNull null]]) {
-        return nil;
-    }
-    else {
-        return [pair first];
-    }
+    return [[self.trackerPairs objectForKey:trackerId] first];
 }
 
 - (nullable NRTracker *)adTracker:(NSNumber *)trackerId {
-    NRTrackerPair *pair = [self.trackerPairs objectForKey:trackerId];
-    if ([[pair second] isEqual:[NSNull null]]) {
-        return nil;
-    }
-    else {
-        return [pair second];
-    }
+    return [[self.trackerPairs objectForKey:trackerId] second];
 }
 
 - (void)setUserId:(NSString *)userId {

--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
@@ -296,9 +296,6 @@
         self.lastContentEventAttributes = [attributes copy];
     }
 
-    // No longer needed - totalPreRollAdTime is now handled internally by QoE aggregator
-
-
     return [super preSendAction:action attributes:attributes];
 }
 

--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
@@ -935,6 +935,24 @@
     // Dirty check: Only send if KPI attributes have changed
     if ([self qoeAttributesChangedFrom:self.lastSentQoEAttributes to:qoeEvent]) {
         self.lastSentQoEAttributes = qoeEvent;
+        NRVA_DEBUG_LOG(@"[QOE_AGGREGATE] => {\n"
+                       "  startupTime          = %@\n"
+                       "  peakBitrate          = %@\n"
+                       "  averageBitrate       = %@\n"
+                       "  totalPlaytime        = %@\n"
+                       "  totalRebufferingTime = %@\n"
+                       "  rebufferingRatio     = %@\n"
+                       "  hadStartupError      = %@\n"
+                       "  hadPlaybackError     = %@\n"
+                       "}",
+                       qoeEvent[@"startupTime"]          ?: @"(nil)",
+                       qoeEvent[@"peakBitrate"]          ?: @"(nil)",
+                       qoeEvent[@"averageBitrate"]        ?: @"(nil)",
+                       qoeEvent[@"totalPlaytime"]         ?: @"(nil)",
+                       qoeEvent[@"totalRebufferingTime"]  ?: @"(nil)",
+                       qoeEvent[@"rebufferingRatio"]      ?: @"(nil)",
+                       qoeEvent[@"hadStartupError"]       ?: @"(nil)",
+                       qoeEvent[@"hadPlaybackError"]      ?: @"(nil)");
         return qoeEvent;
     }
 

--- a/NewRelicVideoCore/NewRelicVideoCoreTests/NREventAttributesValueSanitizationTests.m
+++ b/NewRelicVideoCore/NewRelicVideoCoreTests/NREventAttributesValueSanitizationTests.m
@@ -1,0 +1,187 @@
+//
+//  NREventAttributesValueSanitizationTests.m
+//  NewRelicVideoCoreTests
+//
+//  Regression tests for the JSON-safe value sanitization at the
+//  setAttribute: storage boundary.
+//
+//  Background: setAttribute: accepts `id<NSCopying>` for value, but the
+//  harvest pipeline serializes via NSJSONSerialization, which only accepts
+//  NSString / NSNumber / NSArray / NSDictionary / NSNull. Before this fix,
+//  passing NSDate, NSURL, custom objects, or nested containers holding any
+//  of those would crash the harvest queue asynchronously — far from the
+//  offending callsite, with no link back to source.
+//
+//  Sanitization runs at NREventAttributes.setAttribute: and either
+//    (a) converts the value (NSDate → epoch-seconds NSNumber)
+//    (b) passes it through (NSString, NSNumber, NSNull, JSON-safe containers)
+//    (c) drops it with a debug log (any other type, or nested containers
+//        whose contents are unsanitizable).
+//
+
+@import XCTest;
+#import "NREventAttributes.h"
+
+@interface NREventAttributes (Testing)
+- (nullable id)sanitizedValueForJSON:(id)value;
+- (NSMutableDictionary *)generateAttributes:(NSString *)action append:(nullable NSDictionary *)attributes;
+@end
+
+@interface NREventAttributesValueSanitizationTests : XCTestCase
+
+@property (nonatomic) NREventAttributes *attrs;
+
+@end
+
+@implementation NREventAttributesValueSanitizationTests
+
+- (void)setUp {
+    [super setUp];
+    self.attrs = [[NREventAttributes alloc] init];
+}
+
+- (void)tearDown {
+    self.attrs = nil;
+    [super tearDown];
+}
+
+#pragma mark - sanitizedValueForJSON: pure conversion behaviour
+
+- (void)testStringPassesThroughUnchanged {
+    XCTAssertEqualObjects([self.attrs sanitizedValueForJSON:@"hello"], @"hello");
+}
+
+- (void)testNumberPassesThroughUnchanged {
+    XCTAssertEqualObjects([self.attrs sanitizedValueForJSON:@(42)], @(42));
+    XCTAssertEqualObjects([self.attrs sanitizedValueForJSON:@(3.14)], @(3.14));
+    XCTAssertEqualObjects([self.attrs sanitizedValueForJSON:@YES], @YES);
+}
+
+- (void)testNSNullPassesThrough {
+    XCTAssertEqual([self.attrs sanitizedValueForJSON:[NSNull null]], [NSNull null]);
+}
+
+- (void)testNSDateConvertsToEpochSeconds {
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:1700000000.5];
+    id result = [self.attrs sanitizedValueForJSON:date];
+    XCTAssertTrue([result isKindOfClass:[NSNumber class]]);
+    XCTAssertEqualWithAccuracy([(NSNumber *)result doubleValue], 1700000000.5, 0.001);
+}
+
+- (void)testFlatJSONSafeDictionaryPassesThrough {
+    NSDictionary *input = @{ @"k1": @"string", @"k2": @(7), @"k3": [NSNull null] };
+    id result = [self.attrs sanitizedValueForJSON:input];
+    XCTAssertEqualObjects(result, input);
+}
+
+- (void)testFlatJSONSafeArrayPassesThrough {
+    NSArray *input = @[ @"a", @(1), @YES, [NSNull null] ];
+    id result = [self.attrs sanitizedValueForJSON:input];
+    XCTAssertEqualObjects(result, input);
+}
+
+- (void)testNestedDictionaryWithDateIsRecursivelyConverted {
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:1000];
+    NSDictionary *input = @{ @"label": @"x", @"when": date };
+    id result = [self.attrs sanitizedValueForJSON:input];
+    XCTAssertTrue([result isKindOfClass:[NSDictionary class]]);
+    XCTAssertEqualObjects(result[@"label"], @"x");
+    XCTAssertEqualObjects(result[@"when"], @(1000));
+}
+
+- (void)testArrayWithDateIsRecursivelyConverted {
+    NSArray *input = @[ @"first", [NSDate dateWithTimeIntervalSince1970:500], @(99) ];
+    NSArray *result = [self.attrs sanitizedValueForJSON:input];
+    XCTAssertEqual(result.count, 3);
+    XCTAssertEqualObjects(result[0], @"first");
+    XCTAssertEqualObjects(result[1], @(500));
+    XCTAssertEqualObjects(result[2], @(99));
+}
+
+- (void)testURLIsRejected {
+    XCTAssertNil([self.attrs sanitizedValueForJSON:[NSURL URLWithString:@"https://example.com"]]);
+}
+
+- (void)testDataIsRejected {
+    XCTAssertNil([self.attrs sanitizedValueForJSON:[NSData dataWithBytes:"x" length:1]]);
+}
+
+- (void)testCustomObjectIsRejected {
+    XCTAssertNil([self.attrs sanitizedValueForJSON:[[NSObject alloc] init]]);
+}
+
+- (void)testDictionaryWithNonStringKeyIsRejected {
+    NSDictionary *bad = @{ @(1): @"v" }; // numeric key, not allowed in JSON
+    XCTAssertNil([self.attrs sanitizedValueForJSON:bad]);
+}
+
+- (void)testDictionaryContainingURLIsRejected {
+    NSDictionary *bad = @{ @"link": [NSURL URLWithString:@"https://example.com"] };
+    XCTAssertNil([self.attrs sanitizedValueForJSON:bad], @"reject if any nested element is unsanitizable");
+}
+
+- (void)testArrayContainingURLIsRejected {
+    NSArray *bad = @[ @"ok", [NSURL URLWithString:@"https://example.com"] ];
+    XCTAssertNil([self.attrs sanitizedValueForJSON:bad]);
+}
+
+#pragma mark - setAttribute integration
+
+- (void)testSetAttributeStoresStringValue {
+    [self.attrs setAttribute:@"k" value:@"v" filter:nil];
+    NSDictionary *result = [self.attrs generateAttributes:@"ANY_ACTION" append:nil];
+    XCTAssertEqualObjects(result[@"k"], @"v");
+}
+
+- (void)testSetAttributeConvertsDate {
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:2000];
+    [self.attrs setAttribute:@"when" value:(id<NSCopying>)date filter:nil];
+    NSDictionary *result = [self.attrs generateAttributes:@"ANY_ACTION" append:nil];
+    XCTAssertEqualObjects(result[@"when"], @(2000));
+}
+
+- (void)testSetAttributeDropsURLAndLeavesPriorValue {
+    [self.attrs setAttribute:@"k" value:@"original" filter:nil];
+    [self.attrs setAttribute:@"k"
+                       value:(id<NSCopying>)[NSURL URLWithString:@"https://example.com"]
+                      filter:nil];
+    NSDictionary *result = [self.attrs generateAttributes:@"ANY_ACTION" append:nil];
+    XCTAssertEqualObjects(result[@"k"], @"original",
+                          @"unsanitizable value must be dropped — prior value preserved");
+}
+
+- (void)testSetAttributeDropsURLAndLeavesKeyAbsent {
+    [self.attrs setAttribute:@"never_set" value:(id<NSCopying>)[NSURL URLWithString:@"x"] filter:nil];
+    NSDictionary *result = [self.attrs generateAttributes:@"ANY_ACTION" append:nil];
+    XCTAssertNil(result[@"never_set"], @"unsanitizable value on first write must not create the key");
+}
+
+/**
+ The end-to-end claim of the fix: any value that survives setAttribute must be
+ JSON-serializable. If this passes, the harvest pipeline will not crash on it.
+ */
+- (void)testStoredAttributesAreAlwaysJSONSerializable {
+    [self.attrs setAttribute:@"str" value:@"x" filter:nil];
+    [self.attrs setAttribute:@"num" value:@(7) filter:nil];
+    [self.attrs setAttribute:@"date" value:(id<NSCopying>)[NSDate date] filter:nil];
+    [self.attrs setAttribute:@"nested"
+                       value:@{ @"inner_date": [NSDate dateWithTimeIntervalSince1970:0] }
+                      filter:nil];
+    [self.attrs setAttribute:@"array" value:@[ @(1), @"two", @(3.0) ] filter:nil];
+
+    // These should all be dropped, never reach storage:
+    [self.attrs setAttribute:@"url" value:(id<NSCopying>)[NSURL URLWithString:@"x"] filter:nil];
+    [self.attrs setAttribute:@"data" value:(id<NSCopying>)[NSData data] filter:nil];
+
+    NSDictionary *result = [self.attrs generateAttributes:@"ANY_ACTION" append:nil];
+
+    NSError *err = nil;
+    NSData *json = [NSJSONSerialization dataWithJSONObject:result options:0 error:&err];
+    XCTAssertNotNil(json, @"every stored value must be JSON-serializable");
+    XCTAssertNil(err);
+
+    XCTAssertNil(result[@"url"], @"NSURL must have been dropped");
+    XCTAssertNil(result[@"data"], @"NSData must have been dropped");
+}
+
+@end

--- a/NewRelicVideoCore/NewRelicVideoCoreTests/NREventAttributesValueSanitizationTests.m
+++ b/NewRelicVideoCore/NewRelicVideoCoreTests/NREventAttributesValueSanitizationTests.m
@@ -15,8 +15,9 @@
 //  Sanitization runs at NREventAttributes.setAttribute: and either
 //    (a) converts the value (NSDate → epoch-seconds NSNumber)
 //    (b) passes it through (NSString, NSNumber, NSNull, JSON-safe containers)
-//    (c) drops it with a debug log (any other type, or nested containers
-//        whose contents are unsanitizable).
+//    (c) for NSArray/NSDictionary: strips unsanitizable elements/entries (logged)
+//        and keeps the rest — partial data is better than losing the whole container
+//    (d) drops the entire value with a log (top-level unsanitizable type)
 //
 
 @import XCTest;
@@ -110,19 +111,40 @@
     XCTAssertNil([self.attrs sanitizedValueForJSON:[[NSObject alloc] init]]);
 }
 
-- (void)testDictionaryWithNonStringKeyIsRejected {
-    NSDictionary *bad = @{ @(1): @"v" }; // numeric key, not allowed in JSON
-    XCTAssertNil([self.attrs sanitizedValueForJSON:bad]);
+- (void)testDictionaryWithNonStringKeyDropsEntryKeepsRest {
+    // Numeric key is not JSON-safe — that entry is dropped, but other valid entries survive.
+    NSMutableDictionary *bad = [NSMutableDictionary dictionary];
+    [bad setObject:@"good_value" forKey:@"valid_key"];
+    bad[@(1)] = @"numeric_key_value";  // non-string key — dropped
+    NSDictionary *result = [self.attrs sanitizedValueForJSON:bad];
+    XCTAssertNotNil(result, @"dict is not nil — valid entries are kept");
+    XCTAssertEqualObjects(result[@"valid_key"], @"good_value");
+    XCTAssertEqual(result.count, 1, @"only the valid entry survives");
 }
 
-- (void)testDictionaryContainingURLIsRejected {
-    NSDictionary *bad = @{ @"link": [NSURL URLWithString:@"https://example.com"] };
-    XCTAssertNil([self.attrs sanitizedValueForJSON:bad], @"reject if any nested element is unsanitizable");
+- (void)testDictionaryContainingURLDropsEntryKeepsRest {
+    NSDictionary *mixed = @{ @"ok": @"keep_me", @"link": [NSURL URLWithString:@"https://example.com"] };
+    NSDictionary *result = [self.attrs sanitizedValueForJSON:mixed];
+    XCTAssertNotNil(result, @"dict is not nil — valid entries are kept");
+    XCTAssertEqualObjects(result[@"ok"], @"keep_me");
+    XCTAssertNil(result[@"link"], @"NSURL entry must be stripped");
+    XCTAssertEqual(result.count, 1);
 }
 
-- (void)testArrayContainingURLIsRejected {
-    NSArray *bad = @[ @"ok", [NSURL URLWithString:@"https://example.com"] ];
-    XCTAssertNil([self.attrs sanitizedValueForJSON:bad]);
+- (void)testArrayContainingURLDropsElementKeepsRest {
+    NSArray *mixed = @[ @"ok", [NSURL URLWithString:@"https://example.com"], @(42) ];
+    NSArray *result = [self.attrs sanitizedValueForJSON:mixed];
+    XCTAssertNotNil(result, @"array is not nil — valid elements are kept");
+    XCTAssertEqual(result.count, 2, @"URL element is stripped, the other two survive");
+    XCTAssertEqualObjects(result[0], @"ok");
+    XCTAssertEqualObjects(result[1], @(42));
+}
+
+- (void)testArrayWithAllUnsanitizableElementsReturnsEmptyArray {
+    NSArray *allBad = @[ [NSURL URLWithString:@"x"], [NSData data] ];
+    NSArray *result = [self.attrs sanitizedValueForJSON:allBad];
+    XCTAssertNotNil(result, @"returns empty array, not nil");
+    XCTAssertEqual(result.count, 0);
 }
 
 #pragma mark - setAttribute integration
@@ -156,6 +178,37 @@
     XCTAssertNil(result[@"never_set"], @"unsanitizable value on first write must not create the key");
 }
 
+- (void)testSetAttributeWithNilValueIsSilentlyDropped {
+    // nil should be silently dropped (no error log, no crash, key stays absent)
+    [self.attrs setAttribute:@"k" value:nil filter:nil];
+    NSDictionary *result = [self.attrs generateAttributes:@"ANY_ACTION" append:nil];
+    XCTAssertNil(result[@"k"], @"nil value must be silently dropped without creating the key");
+}
+
+- (void)testSetAttributeArrayWithMixedTypesKeepsValidElements {
+    // Partial container fix: array stores valid elements, strips the NSURL.
+    NSArray *mixed = @[ @"title", [NSURL URLWithString:@"x"], @(99) ];
+    [self.attrs setAttribute:@"arr" value:(id<NSCopying>)mixed filter:nil];
+    NSDictionary *result = [self.attrs generateAttributes:@"ANY_ACTION" append:nil];
+    NSArray *stored = result[@"arr"];
+    XCTAssertNotNil(stored);
+    XCTAssertEqual(stored.count, 2, @"only the two valid elements survive");
+    XCTAssertEqualObjects(stored[0], @"title");
+    XCTAssertEqualObjects(stored[1], @(99));
+}
+
+- (void)testSetAttributeDictWithMixedValuesKeepsValidEntries {
+    // Partial container fix: dict stores valid entries, strips the NSURL value.
+    NSDictionary *mixed = @{ @"label": @"keep", @"link": [NSURL URLWithString:@"x"] };
+    [self.attrs setAttribute:@"meta" value:(id<NSCopying>)mixed filter:nil];
+    NSDictionary *result = [self.attrs generateAttributes:@"ANY_ACTION" append:nil];
+    NSDictionary *stored = result[@"meta"];
+    XCTAssertNotNil(stored);
+    XCTAssertEqual(stored.count, 1);
+    XCTAssertEqualObjects(stored[@"label"], @"keep");
+    XCTAssertNil(stored[@"link"]);
+}
+
 /**
  The end-to-end claim of the fix: any value that survives setAttribute must be
  JSON-serializable. If this passes, the harvest pipeline will not crash on it.
@@ -168,8 +221,11 @@
                        value:@{ @"inner_date": [NSDate dateWithTimeIntervalSince1970:0] }
                       filter:nil];
     [self.attrs setAttribute:@"array" value:@[ @(1), @"two", @(3.0) ] filter:nil];
+    // Mixed array: NSURL stripped, valid elements kept — result must still be JSON-safe.
+    NSArray *mixed = @[ @"good", [NSURL URLWithString:@"x"], @(5) ];
+    [self.attrs setAttribute:@"mixed_array" value:(id<NSCopying>)mixed filter:nil];
 
-    // These should all be dropped, never reach storage:
+    // These top-level unsanitizable values are dropped entirely, never reach storage:
     [self.attrs setAttribute:@"url" value:(id<NSCopying>)[NSURL URLWithString:@"x"] filter:nil];
     [self.attrs setAttribute:@"data" value:(id<NSCopying>)[NSData data] filter:nil];
 
@@ -182,6 +238,9 @@
 
     XCTAssertNil(result[@"url"], @"NSURL must have been dropped");
     XCTAssertNil(result[@"data"], @"NSData must have been dropped");
+
+    NSArray *storedMixed = result[@"mixed_array"];
+    XCTAssertEqual(storedMixed.count, 2, @"valid elements from mixed array survive");
 }
 
 @end

--- a/NewRelicVideoCore/NewRelicVideoCoreTests/NRQoEAggregatorTests.m
+++ b/NewRelicVideoCore/NewRelicVideoCoreTests/NRQoEAggregatorTests.m
@@ -60,9 +60,12 @@
 }
 
 - (void)testStartupTimeSubtractsPreRollAdTime {
+    // Pre-roll ad time is set via setTotalPreRollAdTime: (the NRVideoTracker path),
+    // not via the attributes dict — that key never appears in production event dicts.
     [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator setTotalPreRollAdTime:3000];
     [self.aggregator processAction:CONTENT_START
-                        attributes:@{@"timeSinceRequested": @(8000), @"totalPreRollAdTime": @(3000)}
+                        attributes:@{@"timeSinceRequested": @(8000)}
                          isPlaying:YES];
 
     NSDictionary *result = [self.aggregator generateAggregateAttributes];
@@ -71,9 +74,10 @@
 
 - (void)testStartupTimeClampedToZero {
     [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
-    // Pre-roll ad time exceeds timeSinceRequested — should clamp to 0
+    // Pre-roll ad time exceeds timeSinceRequested — should clamp to 0.
+    [self.aggregator setTotalPreRollAdTime:5000];
     [self.aggregator processAction:CONTENT_START
-                        attributes:@{@"timeSinceRequested": @(2000), @"totalPreRollAdTime": @(5000)}
+                        attributes:@{@"timeSinceRequested": @(2000)}
                          isPlaying:YES];
 
     NSDictionary *result = [self.aggregator generateAggregateAttributes];
@@ -422,10 +426,10 @@
                         attributes:@{@"totalPlaytime": @(0)}
                          isPlaying:NO];
 
+    [self.aggregator setTotalPreRollAdTime:1000];
     [self.aggregator processAction:CONTENT_START
                         attributes:@{
                             @"timeSinceRequested": @(3000),
-                            @"totalPreRollAdTime": @(1000),
                             @"contentBitrate": @(2000000),
                             @"totalPlaytime": @(0)
                         }

--- a/NewRelicVideoCore/NewRelicVideoCoreTests/NRTrackerPairTests.m
+++ b/NewRelicVideoCore/NewRelicVideoCoreTests/NRTrackerPairTests.m
@@ -1,0 +1,71 @@
+//
+//  NRTrackerPairTests.m
+//  NewRelicVideoCoreTests
+//
+//  Regression tests for NRTrackerPair's nil/NSNull handling.
+//
+//  NRTrackerPair stores [NSNull null] internally in place of a missing tracker
+//  because NSArray cannot hold nil. That sentinel must not leak out of the
+//  class — `first` and `second` are declared as nullable and must translate
+//  NSNull back to nil. A regression here causes content-only integrations
+//  (no ad tracker) to crash with `unrecognized selector sent to NSNull`
+//  the first time a caller does `if (pair.second) { [pair.second ...]; }`.
+//
+
+@import XCTest;
+#import "NRTrackerPair.h"
+#import "NRTracker.h"
+
+@interface NRTrackerPairTests : XCTestCase
+@end
+
+@implementation NRTrackerPairTests
+
+- (void)testBothNilReturnsNilForBothGetters {
+    NRTrackerPair *pair = [[NRTrackerPair alloc] initWithFirst:nil second:nil];
+    XCTAssertNil(pair.first, @"first must be nil when constructed with nil");
+    XCTAssertNil(pair.second, @"second must be nil when constructed with nil");
+}
+
+- (void)testNilFirstNeverLeaksAsNSNull {
+    NRTracker *adTracker = [[NRTracker alloc] init];
+    NRTrackerPair *pair = [[NRTrackerPair alloc] initWithFirst:nil second:adTracker];
+
+    XCTAssertNil(pair.first, @"first must be nil — must not leak NSNull");
+    XCTAssertFalse([pair.first isEqual:[NSNull null]], @"first must not be NSNull");
+    XCTAssertEqual(pair.second, adTracker);
+}
+
+- (void)testNilSecondNeverLeaksAsNSNull {
+    NRTracker *contentTracker = [[NRTracker alloc] init];
+    NRTrackerPair *pair = [[NRTrackerPair alloc] initWithFirst:contentTracker second:nil];
+
+    XCTAssertEqual(pair.first, contentTracker);
+    XCTAssertNil(pair.second, @"second must be nil — must not leak NSNull");
+    XCTAssertFalse([pair.second isEqual:[NSNull null]], @"second must not be NSNull");
+}
+
+- (void)testBothPresentReturnsBoth {
+    NRTracker *contentTracker = [[NRTracker alloc] init];
+    NRTracker *adTracker = [[NRTracker alloc] init];
+    NRTrackerPair *pair = [[NRTrackerPair alloc] initWithFirst:contentTracker second:adTracker];
+
+    XCTAssertEqual(pair.first, contentTracker);
+    XCTAssertEqual(pair.second, adTracker);
+}
+
+/**
+ The original Bell/DeltaTre crash signature: a content-only integration calls
+ setUserId / setGlobalAttribute, the loop body does `if (pair.second)` (which
+ used to pass for NSNull), then sends a message to NSNull. With first/second
+ returning nil correctly, the standard truthy check now skips correctly.
+ */
+- (void)testContentOnlyPairIsTruthyCheckable {
+    NRTracker *contentTracker = [[NRTracker alloc] init];
+    NRTrackerPair *pair = [[NRTrackerPair alloc] initWithFirst:contentTracker second:nil];
+
+    XCTAssertTrue((BOOL)pair.first, @"content tracker should be truthy");
+    XCTAssertFalse((BOOL)pair.second, @"missing ad tracker must be falsy (was the bug — NSNull is truthy)");
+}
+
+@end

--- a/NewRelicVideoCore/NewRelicVideoCoreTests/NRVAHarvestManagerQoETests.m
+++ b/NewRelicVideoCore/NewRelicVideoCoreTests/NRVAHarvestManagerQoETests.m
@@ -2,28 +2,27 @@
 //  NRVAHarvestManagerQoETests.m
 //  NewRelicVideoCoreTests
 //
-//  Unit tests for NRVAHarvestManager QoE harvest integration:
-//  multiplier gate, dirty check, and pending final QoE priority.
+//  Unit tests for NRVAHarvestManager's QoE harvest integration.
 //
-//  These tests exercise collectQoeEventIfNeeded and qoeAttributesChangedFrom:to:
-//  by setting the qoeEventProvider directly and calling the public/internal methods.
+//  Architecture note: in the current design (post-aa761f8), the per-cycle
+//  QoE machinery — multiplier gate, dirty-KPI check, pending-final QoE,
+//  cycle counting — lives on NRVideoTracker (generateQoeEventIfNeeded /
+//  qoeAttributesChangedFrom:to:). NRVAHarvestManager is just the collector
+//  that walks active trackers and aggregates their results. Tests for the
+//  per-cycle gating belong on NRVideoTracker, not here. Tests for KPI
+//  computation belong on NRQoEAggregator (already covered).
+//
+//  These tests cover what the harvest manager actually owns now:
+//  empty-tracker behavior and exception isolation across trackers.
 //
 
 @import XCTest;
 #import "NRVAHarvestManager.h"
 #import "NRVAVideoConfiguration.h"
-#import "NRVideoDefs.h"
 
-// Expose private methods for testing
+// Expose internal QoE collection method for testing.
 @interface NRVAHarvestManager (Testing)
-
-- (NSDictionary *)collectQoeEventIfNeeded;
-- (BOOL)qoeAttributesChangedFrom:(NSDictionary *)previous to:(NSDictionary *)current;
-
-@property (nonatomic) NSInteger qoeCycleCount;
-@property (nonatomic, strong) NSDictionary *pendingFinalQoe;
-@property (nonatomic, strong) NSDictionary *lastSentQoEAttributes;
-
+- (NSArray<NSDictionary *> *)collectAllActiveQoeEvents;
 @end
 
 @interface NRVAHarvestManagerQoETests : XCTestCase
@@ -47,345 +46,30 @@
     [super tearDown];
 }
 
-#pragma mark - No Provider
+#pragma mark - collectAllActiveQoeEvents
 
-- (void)testCollectReturnsNilWithNoProvider {
-    NSDictionary *result = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNil(result, @"Should return nil when no provider is set");
+/**
+ With no NRVAVideo instance and no registered trackers, collection must
+ return an empty (non-nil) array — never crash, never nil.
+ */
+- (void)testCollectReturnsEmptyArrayWhenNoActiveTrackers {
+    NSArray<NSDictionary *> *result = [self.harvestManager collectAllActiveQoeEvents];
+    XCTAssertNotNil(result, @"collectAllActiveQoeEvents must never return nil");
+    XCTAssertEqual(result.count, 0, @"With no active trackers, result must be empty");
 }
 
-#pragma mark - Multiplier Gate (Default = 1)
-
-- (void)testFirstCycleAlwaysSendsWithMultiplierOne {
-    __block int providerCallCount = 0;
-    NSDictionary *qoeEvent = @{
-        @"actionName": QOE_AGGREGATE,
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0)
-    };
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        providerCallCount++;
-        return qoeEvent;
-    };
-
-    NSDictionary *result = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNotNil(result, @"First cycle should send with multiplier=1");
-    XCTAssertEqual(providerCallCount, 1);
-}
-
-- (void)testEverySecondCycleWithMultiplierTwo {
-    // Use a config with multiplier=2
-    NRVAVideoConfiguration *config = [[[[NRVAVideoConfiguration builder]
-                                         withApplicationToken:@"test-token"]
-                                        withQoeAggregateIntervalMultiplier:2]
-                                       build];
-    self.harvestManager = [[NRVAHarvestManager alloc] initWithConfiguration:config];
-
-    __block int providerCallCount = 0;
-    NSDictionary *event1 = @{
-        @"actionName": QOE_AGGREGATE,
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0)
-    };
-    NSDictionary *event2 = @{
-        @"actionName": QOE_AGGREGATE,
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @YES,
-        KPI_TOTAL_REBUFFERING_TIME: @(100),
-        KPI_REBUFFERING_RATIO: @(1.0)
-    };
-
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        providerCallCount++;
-        return (providerCallCount <= 1) ? event1 : event2;
-    };
-
-    // Cycle 1: qualifies (first cycle)
-    NSDictionary *result1 = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNotNil(result1, @"Cycle 1 should qualify with multiplier=2");
-
-    // Cycle 2: does NOT qualify
-    NSDictionary *result2 = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNil(result2, @"Cycle 2 should NOT qualify with multiplier=2");
-
-    // Cycle 3: qualifies
-    NSDictionary *result3 = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNotNil(result3, @"Cycle 3 should qualify with multiplier=2");
-}
-
-#pragma mark - Dirty Check
-
-- (void)testFirstQoEEventAlwaysSent {
-    NSDictionary *qoeEvent = @{
-        @"actionName": QOE_AGGREGATE,
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0)
-    };
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        return qoeEvent;
-    };
-
-    NSDictionary *result = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNotNil(result, @"First QoE event should always be sent (no previous snapshot)");
-}
-
-- (void)testUnchangedKPIsAreSkipped {
-    NSDictionary *qoeEvent = @{
-        @"actionName": QOE_AGGREGATE,
-        @"timestamp": @(1000),
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0)
-    };
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        return qoeEvent;
-    };
-
-    // First call — always sent
-    NSDictionary *result1 = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNotNil(result1);
-
-    // Second call with same KPIs — should be skipped
-    NSDictionary *result2 = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNil(result2, @"Should skip when KPI values haven't changed");
-}
-
-- (void)testChangedKPIsAreSent {
-    __block int callCount = 0;
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        callCount++;
-        if (callCount == 1) {
-            return @{
-                @"actionName": QOE_AGGREGATE,
-                KPI_HAD_STARTUP_ERROR: @NO,
-                KPI_HAD_PLAYBACK_ERROR: @NO,
-                KPI_TOTAL_REBUFFERING_TIME: @(0),
-                KPI_REBUFFERING_RATIO: @(0.0)
-            };
-        } else {
-            return @{
-                @"actionName": QOE_AGGREGATE,
-                KPI_HAD_STARTUP_ERROR: @NO,
-                KPI_HAD_PLAYBACK_ERROR: @YES,  // changed!
-                KPI_TOTAL_REBUFFERING_TIME: @(500),  // changed!
-                KPI_REBUFFERING_RATIO: @(1.5)  // changed!
-            };
-        }
-    };
-
-    NSDictionary *result1 = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNotNil(result1, @"First event should be sent");
-
-    NSDictionary *result2 = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNotNil(result2, @"Should send when KPI values changed");
-}
-
-- (void)testDirtyCheckIgnoresMetadataKeys {
-    // Two events with same KPIs but different timestamps — should be skipped
-    __block int callCount = 0;
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        callCount++;
-        return @{
-            @"actionName": QOE_AGGREGATE,
-            @"eventType": NR_VIDEO_EVENT,
-            @"timestamp": @(callCount * 1000),  // different each time
-            KPI_HAD_STARTUP_ERROR: @NO,
-            KPI_HAD_PLAYBACK_ERROR: @NO,
-            KPI_TOTAL_REBUFFERING_TIME: @(0),
-            KPI_REBUFFERING_RATIO: @(0.0)
-        };
-    };
-
-    NSDictionary *result1 = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNotNil(result1, @"First event always sent");
-
-    NSDictionary *result2 = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNil(result2, @"Should skip — only timestamp changed, not KPIs");
-}
-
-#pragma mark - qoeAttributesChangedFrom:to: Direct Tests
-
-- (void)testChangedFromNilAlwaysReturnsYES {
-    NSDictionary *current = @{KPI_HAD_STARTUP_ERROR: @NO};
-    BOOL changed = [self.harvestManager qoeAttributesChangedFrom:nil to:current];
-    XCTAssertTrue(changed, @"Should always return YES when previous is nil");
-}
-
-- (void)testChangedFromEqualReturnNO {
-    NSDictionary *event = @{
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0)
-    };
-    BOOL changed = [self.harvestManager qoeAttributesChangedFrom:event to:event];
-    XCTAssertFalse(changed, @"Should return NO when all KPIs are equal");
-}
-
-- (void)testChangedWhenKPIAppearsReturnsYES {
-    NSDictionary *prev = @{
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0)
-    };
-    NSDictionary *curr = @{
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0),
-        KPI_STARTUP_TIME: @(2000)  // new KPI appeared
-    };
-    BOOL changed = [self.harvestManager qoeAttributesChangedFrom:prev to:curr];
-    XCTAssertTrue(changed, @"Should return YES when a KPI appears in current but not previous");
-}
-
-- (void)testChangedWhenKPIDisappearsReturnsYES {
-    NSDictionary *prev = @{
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0),
-        KPI_STARTUP_TIME: @(2000)
-    };
-    NSDictionary *curr = @{
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0)
-        // KPI_STARTUP_TIME gone
-    };
-    BOOL changed = [self.harvestManager qoeAttributesChangedFrom:prev to:curr];
-    XCTAssertTrue(changed, @"Should return YES when a KPI disappears from current");
-}
-
-#pragma mark - Pending Final QoE
-
-- (void)testPendingFinalQoETakesPriority {
-    // Set up both a provider and a pending final QoE
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        return @{@"actionName": QOE_AGGREGATE, @"source": @"provider"};
-    };
-
-    NSDictionary *finalEvent = @{
-        @"actionName": QOE_AGGREGATE,
-        @"source": @"final",
-        KPI_TOTAL_REBUFFERING_TIME: @(0)
-    };
-    // Directly set pendingFinalQoe (bypassing dispatch_async for test synchronicity)
-    self.harvestManager.pendingFinalQoe = finalEvent;
-
-    NSDictionary *result = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertEqualObjects(result[@"source"], @"final",
-                          @"Pending final QoE should take priority over provider");
-}
-
-- (void)testPendingFinalQoEClearsProvider {
-    __block int providerCalled = 0;
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        providerCalled++;
-        return @{@"actionName": QOE_AGGREGATE};
-    };
-
-    NSDictionary *finalEvent = @{@"actionName": QOE_AGGREGATE, KPI_TOTAL_REBUFFERING_TIME: @(0)};
-    self.harvestManager.pendingFinalQoe = finalEvent;
-
-    // Collect final — should clear provider
-    [self.harvestManager collectQoeEventIfNeeded];
-
-    // Next collect should return nil (provider was cleared)
-    NSDictionary *result = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNil(result, @"Provider should be nil after final QoE is collected");
-    XCTAssertEqual(providerCalled, 0, @"Provider should never have been called");
-}
-
-- (void)testPendingFinalQoEClearsSnapshotForNextSession {
-    // Build up a snapshot from first session
-    NSDictionary *event = @{
-        @"actionName": QOE_AGGREGATE,
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0)
-    };
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        return event;
-    };
-    [self.harvestManager collectQoeEventIfNeeded];  // Sets lastSentQoEAttributes
-
-    // Now simulate CONTENT_END with final QoE
-    NSDictionary *finalEvent = @{@"actionName": QOE_AGGREGATE, KPI_TOTAL_REBUFFERING_TIME: @(0)};
-    self.harvestManager.pendingFinalQoe = finalEvent;
-    [self.harvestManager collectQoeEventIfNeeded];  // Clears snapshot
-
-    XCTAssertNil(self.harvestManager.lastSentQoEAttributes,
-                 @"Snapshot should be cleared after final QoE for next session");
-}
-
-- (void)testPendingFinalQoEResetsCycleCount {
-    // Simulate a few cycles
-    NSDictionary *event = @{
-        @"actionName": QOE_AGGREGATE,
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0)
-    };
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        return event;
-    };
-    [self.harvestManager collectQoeEventIfNeeded]; // cycle 1
-    [self.harvestManager collectQoeEventIfNeeded]; // cycle 2
-
-    // Final QoE
-    NSDictionary *finalEvent = @{@"actionName": QOE_AGGREGATE, KPI_TOTAL_REBUFFERING_TIME: @(0)};
-    self.harvestManager.pendingFinalQoe = finalEvent;
-    [self.harvestManager collectQoeEventIfNeeded];
-
-    XCTAssertEqual(self.harvestManager.qoeCycleCount, 0,
-                   @"Cycle count should be reset after final QoE");
-}
-
-#pragma mark - Provider Returns Nil
-
-- (void)testProviderReturningNilDoesNotSend {
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        return nil;
-    };
-
-    NSDictionary *result = [self.harvestManager collectQoeEventIfNeeded];
-    XCTAssertNil(result, @"Should not send when provider returns nil");
-}
-
-#pragma mark - Setting Provider Resets Cycle Count
-
-- (void)testSettingProviderResetsCycleCount {
-    NSDictionary *event = @{
-        @"actionName": QOE_AGGREGATE,
-        KPI_HAD_STARTUP_ERROR: @NO,
-        KPI_HAD_PLAYBACK_ERROR: @NO,
-        KPI_TOTAL_REBUFFERING_TIME: @(0),
-        KPI_REBUFFERING_RATIO: @(0.0)
-    };
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        return event;
-    };
-    [self.harvestManager collectQoeEventIfNeeded]; // cycle 1
-
-    // Re-set provider (simulates new session)
-    self.harvestManager.qoeEventProvider = ^NSDictionary * {
-        return event;
-    };
-
-    XCTAssertEqual(self.harvestManager.qoeCycleCount, 0,
-                   @"Setting provider should reset cycle count");
+/**
+ Repeated calls to collectAllActiveQoeEvents must be safe and idempotent
+ when there's no underlying state. Defends against any future caching that
+ might assume first-call behavior.
+ */
+- (void)testCollectIsIdempotentWithNoActiveTrackers {
+    NSArray *first  = [self.harvestManager collectAllActiveQoeEvents];
+    NSArray *second = [self.harvestManager collectAllActiveQoeEvents];
+    NSArray *third  = [self.harvestManager collectAllActiveQoeEvents];
+    XCTAssertEqual(first.count, 0);
+    XCTAssertEqual(second.count, 0);
+    XCTAssertEqual(third.count, 0);
 }
 
 @end

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -813,15 +813,21 @@ Add custom metadata to your video tracking:
 #### Swift
 
 ```swift
-// Set attributes for specific tracker
+// String
 NRVAVideo.setAttribute(trackerId, key: "videoGenre", value: "Documentary")
+
+// Number / Bool
+NRVAVideo.setAttribute(trackerId, key: "contentResolution", value: 1080)
+NRVAVideo.setAttribute(trackerId, key: "isDVR", value: true)
+
+// Date — stored as epoch seconds
+NRVAVideo.setAttribute(trackerId, key: "sessionStart", value: Date())
 
 // Set global attributes (applies to all trackers)
 NRVAVideo.setGlobalAttribute("userTier", value: "Premium")
-
-// Set ad-specific attributes
-NRVAVideo.setAdAttribute(trackerId, key: "adCampaign", value: "Summer2024")
 ```
+
+Accepted value types: `String`/`NSString`, `Int`/`Double`/`Bool`/`NSNumber`, `Date`/`NSDate` (converted to epoch seconds), `Array`/`NSArray`, `[String: Any]`/`NSDictionary`. Unsupported types (`URL`, `Data`, custom objects) are dropped with an error log.
 
 ### User Identification
 

--- a/README.md
+++ b/README.md
@@ -256,11 +256,15 @@ let playerConfig = NRVAVideoPlayerConfiguration(
 You can also set attributes after initialization:
 
 ```swift
-// Set attribute on a specific content tracker
+// String
 NRVAVideo.setAttribute("contentSeries", value: "Season 1", trackerId: trackerId)
 
-// Set attribute on ad tracker
-NRVAVideo.setAdAttribute("adCampaign", value: "spring-promo", trackerId: trackerId)
+// Number / Bool
+NRVAVideo.setAttribute("contentResolution", value: 1080, trackerId: trackerId)
+NRVAVideo.setAttribute("isDVR", value: true, trackerId: trackerId)
+
+// Date — automatically converted to epoch seconds
+NRVAVideo.setAttribute("sessionStart", value: Date(), trackerId: trackerId)
 
 // Set global attribute across all trackers
 NRVAVideo.setGlobalAttribute("appVersion", value: "2.1.0")
@@ -332,6 +336,18 @@ Limits for custom attributes added to default mobile events:
 
 - **Attributes:** 128 maximum
 - **String attributes:** 4 KB maximum length (empty string values are not accepted)
+
+### Accepted Attribute Value Types
+
+| Type | Behaviour | Example |
+|------|-----------|---------|
+| `NSString` / `String` | Stored as-is | `"premium"` |
+| `NSNumber` / `Int`, `Double`, `Bool` | Stored as-is | `@(1080)`, `true` |
+| `NSDate` / `Date` | Converted to epoch seconds (`NSNumber`) | `NSDate.now` |
+| `NSArray` / `Array` | Stored recursively; invalid elements are dropped | `@[@"hls", @(4)]` |
+| `NSDictionary` / `[String: Any]` | Stored recursively; entries with non-string keys or invalid values are dropped | `@{@"cdn": @"cloudflare"}` |
+| `NSNull` | Stored as JSON `null` | `[NSNull null]` |
+| Anything else (`NSURL`, `NSData`, custom objects…) | **Dropped** with an error log; key is not stored | — |
 
 > **Note:** There are special keywords reserved for default attributes documented in [DATAMODEL.md](./DATAMODEL.md). Do not use these as custom attribute names, as they will be dropped by the agent.
 

--- a/advanced.md
+++ b/advanced.md
@@ -188,7 +188,10 @@ We can also set custom attributes for all events:
 <p>
 
 ```Objective-C
-[tracker setAttribute:@"myAttr" value:@"myVal"];
+[tracker setAttribute:@"myAttr" value:@"myVal"];          // NSString
+[tracker setAttribute:@"resolution" value:@(1080)];       // NSNumber
+[tracker setAttribute:@"isDVR" value:@YES];               // BOOL
+[tracker setAttribute:@"sessionStart" value:[NSDate date]]; // NSDate → stored as epoch seconds
 ```
 
 </p>
@@ -203,6 +206,8 @@ tracker.setAttribute("myAttr", "myVal");
 
 </p>
 </details>
+
+Accepted value types (iOS): `NSString`, `NSNumber` (including `BOOL`), `NSDate` (converted to epoch seconds), `NSArray`, `NSDictionary` (string keys only). Unsupported types such as `NSURL` or `NSData` are dropped with a log.
 
 Or only for specific events, specifiying a regexp filter for the action:
 


### PR DESCRIPTION
## What changed

**Crash fix — content-only tracker (NSNull leak)**
`setUserId` and `setGlobalAttribute` crashed when no ad tracker was registered. `NRTrackerPair` was leaking `NSNull` from its getters — NSNull is truthy so the nil-guard passed, then the message send exploded. Fixed at the source: getters now return `nil` correctly.

**Crash fix — unsafe attribute values**
Passing `NSDate`, `NSURL`, or custom objects to `setAttribute:` crashed asynchronously at harvest time with no stack link back to the caller. Added sanitization at the storage boundary: `NSDate` converts to epoch seconds, unsupported types are dropped with a log, `nil` is silently ignored.

**Seek events — auto-detection in AVPlayerTracker**
`CONTENT_SEEK_START` never fired for `AVPlayerViewController` integrations. The tracker was waiting for `state.startSeekingEvent` to be called externally — which nothing ever called. Fixed by auto-detecting seeks via `timeControlStatus`. Also exposes `NRVAVideo.sendSeekStart:` / `sendSeekEnd:` for custom player integrations.

**Dead code removal**
Removed a QoE pre-roll code path that read from the event attributes dict — that key never existed in production. Also removed an unreachable `!self` guard and a stale comment.

**tvOS test scheme**
Added shared scheme so `xcodebuild test` runs on tvOS without manual setup.

**Docs**
README, advanced.md, ONBOARDING.md updated with accepted attribute value types and examples.

## Test results

78/78 unit tests passing.

UI tested on iOS simulator against pod 4.1.2 (before) and fix branch (after).
Full test checklist and results: https://github.com/newrelic/video-agent-iOS/tree/test/v4.1.4

| Section | Result |
|---------|--------|
| Crash regressions (CR-1/2/3) | ❌ crash on 4.1.2 → ✅ pass on fix branch |
| Attribute sanitization (DQ-1/2/3/4) | Before: wrong types stored → After: correct types |
| Record events (REC-1/2/3/4) | ✅ all events fire correctly |
| Core event lifecycle (SAN-1 to SAN-8) | ✅ all events including seek |
| Ad data propagation (AD-1 to AD-6) | ✅ pre/mid/post-roll, quartiles, errors |
| QoE harvest (QoE-1 to QoE-7) | ✅ startupTime, rebufferingRatio, error flags |