### PR TITLE
feat: enable QoE by default with interval multiplier 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [4.1.4](https://github.com/newrelic/video-agent-iOS/compare/v4.1.3...v4.1.4) (2026-06-05)
+
+### Bug Fixes
+
+* expose sendSeekStart/sendSeekEnd on NRVAVideo; auto-detect seek in AVPlayerTracker ([34493b4](https://github.com/newrelic/video-agent-iOS/commit/34493b4999968ff4e726c3f3ba3d266ff6d3f4e2))
+* NRTrackerPair must not leak NSNull sentinel to callers ([82ef94f](https://github.com/newrelic/video-agent-iOS/commit/82ef94fcbd4f432dedf2dabbc523a19fe8134d34))
+* partial container sanitization, nil guard, and dead code removal ([6aac79f](https://github.com/newrelic/video-agent-iOS/commit/6aac79f7ef52d648a4f3c0636ed97d5b01edc314))
+* read totalPreRollAdTime from CONTENT_START attributes ([d565378](https://github.com/newrelic/video-agent-iOS/commit/d565378286af59e2d7109566bc0081ea31872246))
+* sanitize attribute values at setAttribute storage boundary ([7d07298](https://github.com/newrelic/video-agent-iOS/commit/7d072980d1e6b4a85339c864ea8245194a38f688))
+
 ## [4.1.3](https://github.com/newrelic/video-agent-iOS/compare/v4.1.2...v4.1.3) (2026-05-20)
 
 ### Bug Fixes

--- a/NRAVPlayerTracker.podspec
+++ b/NRAVPlayerTracker.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NRAVPlayerTracker'
-  s.version          = '4.1.3'
+  s.version          = '4.1.4'
   s.summary          = 'New Relic Video Agent, AVPlayer Tracker.'
 
 # This description is used to generate tags and improve search results.

--- a/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
+++ b/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
@@ -406,7 +406,7 @@
 
 
 - (NSString *)getTrackerVersion {
-    return @"4.1.3";
+    return @"4.1.4";
 }
 
 - (NSString *)getPlayerVersion {

--- a/NRIMATracker.podspec
+++ b/NRIMATracker.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NRIMATracker'
-  s.version          = '4.1.3'
+  s.version          = '4.1.4'
   s.summary          = 'New Relic Video Agent, Google IMA Ads Tracker.'
 
 # This description is used to generate tags and improve search results.

--- a/NRIMATracker/NRIMATracker/Tracker/NRTrackerIMA.m
+++ b/NRIMATracker/NRIMATracker/Tracker/NRTrackerIMA.m
@@ -104,7 +104,7 @@
 }
 
 - (NSString *)getTrackerVersion {
-    return @"4.1.3";
+    return @"4.1.4";
 }
 
 - (NSNumber *)getPlayhead {

--- a/NewRelicVideoAgent.podspec
+++ b/NewRelicVideoAgent.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NewRelicVideoAgent'
-  s.version          = '4.1.3'
+  s.version          = '4.1.4'
   s.summary          = 'New Relic Video Agent for iOS'
 
 # This description is used to generate tags and improve search results.

--- a/NewRelicVideoCore/NewRelicVideoCore/Auth/NRVATokenManager.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Auth/NRVATokenManager.m
@@ -277,7 +277,7 @@ static const NSTimeInterval kNRVA_READ_TIMEOUT = 30.0;    // 30 seconds for TV n
     NSString *osVersion = [[UIDevice currentDevice] systemVersion];
     NSString *architecture = [self getArchitecture];
     NSString *agentName = @"NewRelic-VideoAgent-iOS";
-    NSString *agentVersion = @"4.1.3";
+    NSString *agentVersion = @"4.1.4";
     NSString *deviceId = [NRVAUtils generateSessionId]; // Use session ID as device identifier
     NSString *manufacturer = @"Apple";
     

--- a/NewRelicVideoCore/NewRelicVideoCore/Device/NRVADeviceInformation.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Device/NRVADeviceInformation.m
@@ -65,7 +65,7 @@ static dispatch_once_t onceToken;
         self.osBuild = [self getOSBuildVersion];
         self.model = [[UIDevice currentDevice] model];
         self.agentName = @"NewRelic-VideoAgent-iOS";
-        self.agentVersion = @"4.1.3"; // Should be pulled from build configuration
+        self.agentVersion = @"4.1.4"; // Should be pulled from build configuration
         self.manufacturer = @"Apple";
         self.deviceId = [self generatePersistentDeviceId];
         self.architecture = [self getSystemArchitecture];
@@ -93,7 +93,7 @@ static dispatch_once_t onceToken;
     self.osBuild = @"Unknown";
     self.model = @"Unknown";
     self.agentName = @"NewRelic-VideoAgent-iOS";
-    self.agentVersion = @"4.1.3";
+    self.agentVersion = @"4.1.4";
     self.manufacturer = @"Apple";
     self.deviceId = [[NSUUID UUID] UUIDString];
     self.architecture = @"unknown";
@@ -101,7 +101,7 @@ static dispatch_once_t onceToken;
     self.size = @""; // Empty string for now
     self.applicationFramework = @"Native iOS";
     self.applicationFrameworkVersion = @"Unknown";
-    self.userAgent = @"NewRelic-VideoAgent-iOS/4.1.3";
+    self.userAgent = @"NewRelic-VideoAgent-iOS/4.1.4";
     self.isTV = NO;
     self.isLowMemoryDevice = NO;
 }

--- a/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAOptimizedHttpClient.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAOptimizedHttpClient.m
@@ -218,7 +218,7 @@ static const int kMaxRetryAttempts = 3;
     NSString *osVersion = [[UIDevice currentDevice] systemVersion];
     NSString *architecture = [self getArchitecture];
     NSString *agentName = @"NewRelic-VideoAgent-iOS";
-    NSString *agentVersion = @"4.1.3";
+    NSString *agentVersion = @"4.1.4";
     NSString *deviceId = [NRVAUtils generateSessionId];
     NSString *manufacturer = @"Apple";
     

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.m
@@ -203,8 +203,8 @@ static const NSInteger kMemoryOptimizedMaxOfflineStorageSizeMB = 50; // 50MB
 
         _debugLoggingEnabled = NO;
         _collectorAddress = nil; // Will use default based on region
-        _qoeAggregateEnabled = NO;
-        _qoeAggregateIntervalMultiplier = 1;
+        _qoeAggregateEnabled = YES;
+        _qoeAggregateIntervalMultiplier = 2;
         _obfuscationRules = nil;
     }
     return self;

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVideoDefs.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVideoDefs.h
@@ -8,7 +8,7 @@
 #ifndef NRVideoDefs_h
 #define NRVideoDefs_h
 
-#define NRVIDEO_CORE_VERSION        @"4.1.3"
+#define NRVIDEO_CORE_VERSION        @"4.1.4"
 
 #define NR_VIDEO_EVENT              @"VideoAction"
 #define NR_VIDEO_AD_EVENT           @"VideoAdAction"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Download the latest pre-built XCFrameworks from the [Releases](https://github.co
 Add the dependencies to your `Podfile`:
 
 ```ruby
-pod 'NewRelicVideoCore'
+pod 'NewRelicVideoAgent'
 pod 'NRAVPlayerTracker'
 pod 'NRIMATracker'   # Optional — only if using Google IMA ads
 ```

--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ if shouldEnable {
 | `withApplicationToken(_:)` | `String` | — | **Required.** Your New Relic application token. |
 | `withHarvestCycle(_:)` | `Int` | 300 (Mobile) / 180 (TV) | Interval in seconds between data harvests. |
 | `withDebugLogging(_:)` | `Bool` | `false` | Enable debug logging for development. |
-| `withQoeAggregate(_:)` | `Bool` | `false` | Enable Quality of Experience event aggregation. |
+| `withQoeAggregateEnabled(_:)` | `Bool` | `true` | QoE aggregation is enabled out of the box. Disable with `withQoeAggregateEnabled(NO)`. |
+| `withQoeAggregateIntervalMultiplier(_:)` | `Int` | `2` | Multiplier applied to the harvest interval for QoE aggregation. Configure with `withQoeAggregateIntervalMultiplier:`. |
 
 ### NRVAVideoPlayerConfiguration
 


### PR DESCRIPTION
Enables QoE tracking by default and sets the interval multiplier default to 2. Part of NR-573376.