### PR TITLE
feat: enable QoE by default with interval multiplier 2

### DIFF
--- a/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVAVideoConfiguration.m
@@ -203,8 +203,8 @@ static const NSInteger kMemoryOptimizedMaxOfflineStorageSizeMB = 50; // 50MB
 
         _debugLoggingEnabled = NO;
         _collectorAddress = nil; // Will use default based on region
-        _qoeAggregateEnabled = NO;
-        _qoeAggregateIntervalMultiplier = 1;
+        _qoeAggregateEnabled = YES;
+        _qoeAggregateIntervalMultiplier = 2;
         _obfuscationRules = nil;
     }
     return self;

--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ if shouldEnable {
 | `withApplicationToken(_:)` | `String` | — | **Required.** Your New Relic application token. |
 | `withHarvestCycle(_:)` | `Int` | 300 (Mobile) / 180 (TV) | Interval in seconds between data harvests. |
 | `withDebugLogging(_:)` | `Bool` | `false` | Enable debug logging for development. |
-| `withQoeAggregate(_:)` | `Bool` | `false` | Enable Quality of Experience event aggregation. |
+| `withQoeAggregateEnabled(_:)` | `Bool` | `true` | QoE aggregation is enabled out of the box. Disable with `withQoeAggregateEnabled(NO)`. |
+| `withQoeAggregateIntervalMultiplier(_:)` | `Int` | `2` | Multiplier applied to the harvest interval for QoE aggregation. Configure with `withQoeAggregateIntervalMultiplier:`. |
 
 ### NRVAVideoPlayerConfiguration
 


### PR DESCRIPTION
Enables QoE tracking by default and sets the interval multiplier default to 2. Part of NR-573376.