### PR TITLE
feat(qoe): add 7 new aggregate KPIs

### DIFF
--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -108,6 +108,14 @@ QOE_AGGREGATE events carry all standard VideoAction attributes (viewId, viewSess
 | rebufferingRatio          | Rebuffering time as a percentage of total playtime: (totalRebufferingTime / totalPlaytime) * 100.                    |
 | hadStartupError           | True if an error occurred before content start.                                                                      |
 | hadPlaybackError          | True if an error occurred after content start.                                                                       |
+| avgDownloadRate           | Mean of every observed network download throughput sample during content (bps). Consecutive duplicate samples are de-duped to avoid bias from idle windows where the player reports the same stale value. Omitted when no sample was observed. |
+| minDownloadRate           | Minimum observed network download throughput sample during content (bps). Omitted when no sample was observed.       |
+| maxDownloadRate           | Maximum observed network download throughput sample during content (bps). Omitted when no sample was observed.       |
+| totalSwitchUps            | Count of content rendition changes whose new bitrate was higher than the previous rendition.                         |
+| totalSwitchDowns          | Count of content rendition changes whose new bitrate was lower than the previous rendition.                          |
+| totalPauseTime            | Total content pause duration (ms). Includes any currently-open pause at emit time, so mid-pause harvests report a growing value rather than a stale one. |
+| totalRenditions           | Count of distinct content renditions observed during the session, keyed by `contentRenditionWidth × contentRenditionHeight`. Pixel-area keying is robust to streams that label distinct resolution variants with the same bitrate. |
+| qoeAggregateVersion       | Schema version of the QOE_AGGREGATE event (currently `1.1.0`). Bump when the KPI set or semantics change.            |
 
 ### VideoAdAction
 

--- a/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
+++ b/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
@@ -530,7 +530,12 @@
     [self sendResume];
     // Send END
     [super sendEnd];
-    
+
+    // Reset the rendition-shift baseline so the NEXT view's first rendition is
+    // treated as a first observation
+    self.lastRenditionWidth = 0;
+    self.lastRenditionHeight = 0;
+
     AV_LOG(@"(AVPlayerTracker) sendEnd");
 }
 

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.h
@@ -59,6 +59,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)processAction:(NSString *)action attributes:(NSDictionary *)attributes isPlaying:(BOOL)isPlaying;
 
 /**
+ As above, but marks whether this content event occurred during an ad break.
+ A CONTENT_PAUSE delivered with adBreakActive == YES is the player paused for an
+ ad, not a user pause, so it is excluded from totalPauseTime.
+
+ @param adBreakActive Whether an ad break is currently in progress (from the linked ad tracker).
+ */
+- (void)processAction:(NSString *)action attributes:(NSDictionary *)attributes isPlaying:(BOOL)isPlaying adBreakActive:(BOOL)adBreakActive;
+
+/**
  Generate the QoE aggregate attributes dictionary.
  Includes the current in-progress bitrate segment in the average calculation
  so that intermediate reports (during playback) are accurate.

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
@@ -11,6 +11,7 @@
 
 @interface NRQoEAggregator () {
     long _totalPreRollAdTime;  // Instance variable for startup calculation
+    BOOL _adBreakActive;       // YES while the current content event occurs during an ad break
 }
 
 // --- Lifecycle flags ---
@@ -105,6 +106,7 @@
         self.pauseStartTimestamp = 0;
         self.playedRenditions = [NSMutableSet set];
         _totalPreRollAdTime = 0;
+        _adBreakActive = NO;
     }
 }
 
@@ -150,7 +152,14 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
 // At this point, the tracker pipeline has already assembled all attributes
 // (timeSince values, bitrate, playtime, bufferType, etc.), so we just read them.
 - (void)processAction:(NSString *)action attributes:(NSDictionary *)attributes isPlaying:(BOOL)isPlaying {
+    [self processAction:action attributes:attributes isPlaying:isPlaying adBreakActive:NO];
+}
+
+- (void)processAction:(NSString *)action attributes:(NSDictionary *)attributes isPlaying:(BOOL)isPlaying adBreakActive:(BOOL)adBreakActive {
     @synchronized (self) {
+        // Stash ad-break state before the action handler runs (handlePause reads it).
+        _adBreakActive = adBreakActive;
+
         // Always grab the latest totalPlaytime — the tracker updates this before every event
         NSNumber *playtime = attributes[@"totalPlaytime"];
         if (playtime) {
@@ -375,6 +384,11 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
 // CONTENT_PAUSE: arm the open-segment timer. The closed-segment accumulator
 // is NOT touched here — it gets fed by timeSincePaused on the matching RESUME.
 - (void)handlePause {
+    // A content pause during an ad break is the player paused for the ad, not a
+    // user pause — don't arm the timer, so it isn't counted in totalPauseTime.
+    if (_adBreakActive) {
+        return;
+    }
     self.pauseStartTimestamp = [[NSDate date] timeIntervalSince1970];
 }
 
@@ -383,8 +397,9 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
 //
 // IMPORTANT: pauseStartTimestamp = 0 MUST happen here.
 - (void)handleResumeWithAttributes:(NSDictionary *)attributes {
+    // Only bank the closed segment if the matching pause armed the timer.
     NSNumber *timeSincePaused = attributes[@"timeSincePaused"];
-    if (timeSincePaused) {
+    if (timeSincePaused && self.pauseStartTimestamp > 0) {
         self.totalPauseTime += [timeSincePaused longValue];
     }
     self.pauseStartTimestamp = 0;

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
@@ -54,6 +54,8 @@
 @property (nonatomic) long downloadRateSampleCount;                // how many readings we've seen
 @property (nonatomic, strong, nullable) NSNumber *minDownloadRate; // smallest reading so far
 @property (nonatomic, strong, nullable) NSNumber *maxDownloadRate; // largest reading so far
+// Last accepted sample. nil until the first observation.
+@property (nonatomic, strong, nullable) NSNumber *lastDownloadRateSample;
 
 // --- Rendition switch counts ---
 @property (nonatomic) long totalSwitchUps;    // count of quality upgrades   (shift == "up")
@@ -93,6 +95,7 @@
         self.downloadRateSampleCount = 0;
         self.minDownloadRate = nil;
         self.maxDownloadRate = nil;
+        self.lastDownloadRateSample = nil;
         self.totalSwitchUps = 0;
         self.totalSwitchDowns = 0;
         self.hadStartupError = NO;
@@ -445,7 +448,12 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
         return;
     }
 
-    // --- This is a valid reading. Update our 4 tallies. ---
+    if (self.lastDownloadRateSample != nil
+        && [self.lastDownloadRateSample longValue] == sample) {
+        return;
+    }
+    self.lastDownloadRateSample = @(sample);
+
     self.downloadRateSum += sample;
     self.downloadRateSampleCount += 1;
 

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
@@ -172,6 +172,10 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
         // Track bitrate from every content event for time-weighted average + peak
         [self updateBitrateFromAttributes:attributes];
 
+        // CONTENT_RENDITION_CHANGE. Recording here lets the first event carrying a valid
+        // W×H (e.g. CONTENT_BUFFER_END / heartbeat) seed the set. The Set dedups, so repeats don't over-count.
+        [self recordCurrentRenditionFromAttributes:attributes];
+
         // Action-specific KPI extraction via dispatch table
         QoEActionHandler handler = sActionHandlers[action];
         if (handler) {

--- a/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Model/NRQoEAggregator.m
@@ -50,6 +50,22 @@
 // Used to compute rebufferingRatio = (totalRebufferingTime / lastTotalPlaytime) * 100
 @property (nonatomic) long lastTotalPlaytime;     // ms, latest value from event attributes
 
+@property (nonatomic) double downloadRateSum;                      // running total of all readings
+@property (nonatomic) long downloadRateSampleCount;                // how many readings we've seen
+@property (nonatomic, strong, nullable) NSNumber *minDownloadRate; // smallest reading so far
+@property (nonatomic, strong, nullable) NSNumber *maxDownloadRate; // largest reading so far
+
+// --- Rendition switch counts ---
+@property (nonatomic) long totalSwitchUps;    // count of quality upgrades   (shift == "up")
+@property (nonatomic) long totalSwitchDowns;  // count of quality downgrades (shift == "down")
+
+// --- Pause accumulator ---
+@property (nonatomic) long totalPauseTime;              // ms; closed-segment total
+@property (nonatomic) NSTimeInterval pauseStartTimestamp; // wall-clock secs; 0 = not paused
+
+// --- Distinct content renditions seen this session ---
+@property (nonatomic, strong) NSMutableSet<NSNumber *> *playedRenditions;
+
 @end
 
 @implementation NRQoEAggregator
@@ -73,9 +89,18 @@
         self.bitrateTotalDuration = 0;
         self.totalRebufferingTime = 0;
         self.hasSkippedFirstBuffer = NO;
+        self.downloadRateSum = 0;
+        self.downloadRateSampleCount = 0;
+        self.minDownloadRate = nil;
+        self.maxDownloadRate = nil;
+        self.totalSwitchUps = 0;
+        self.totalSwitchDowns = 0;
         self.hadStartupError = NO;
         self.hadPlaybackError = NO;
         self.lastTotalPlaytime = 0;
+        self.totalPauseTime = 0;
+        self.pauseStartTimestamp = 0;
+        self.playedRenditions = [NSMutableSet set];
         _totalPreRollAdTime = 0;
     }
 }
@@ -104,7 +129,17 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
             CONTENT_END:        ^(NRQoEAggregator *agg, NSDictionary *attrs) {
                 [agg flushBitrateSegment];
             },
+            CONTENT_RENDITION_CHANGE: ^(NRQoEAggregator *agg, NSDictionary *attrs) {
+                [agg handleRenditionChangeWithAttributes:attrs];
+            },
+            CONTENT_PAUSE: ^(NRQoEAggregator *agg, NSDictionary *attrs) {
+                [agg handlePause];
+            },
+            CONTENT_RESUME: ^(NRQoEAggregator *agg, NSDictionary *attrs) {
+                [agg handleResumeWithAttributes:attrs];
+            },
         };
+
     }
 }
 
@@ -128,6 +163,8 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
         } else if (!timerRunning && isPlaying) {
             [self resumeBitrateTimer];
         }
+
+        [self updateDownloadRateFromAttributes:attributes];
 
         // Track bitrate from every content event for time-weighted average + peak
         [self updateBitrateFromAttributes:attributes];
@@ -191,6 +228,18 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
             } else {
                 attrs[KPI_REBUFFERING_RATIO] = @(0.0);
             }
+
+            // --- Total pause time (ms) ---
+            // For mid-pause harvests.
+            long pauseTime = self.totalPauseTime;
+            if (self.pauseStartTimestamp > 0) {
+                NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+                long openSegment = (long)((now - self.pauseStartTimestamp) * 1000.0);
+                if (openSegment > 0) {
+                    pauseTime += openSegment;
+                }
+            }
+            attrs[KPI_TOTAL_PAUSE_TIME] = @(pauseTime);
         }
 
         // --- Error flags ---
@@ -204,6 +253,24 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
             // Error before start — report it immediately
             attrs[KPI_HAD_STARTUP_ERROR] = @YES;
         }
+
+        // network download bitrate.
+        if (self.downloadRateSampleCount > 0) {
+            attrs[KPI_AVG_DOWNLOAD_RATE] = @((long)round(self.downloadRateSum / self.downloadRateSampleCount));
+        }
+        if (self.minDownloadRate != nil) {
+            attrs[KPI_MIN_DOWNLOAD_RATE] = self.minDownloadRate;
+        }
+        if (self.maxDownloadRate != nil) {
+            attrs[KPI_MAX_DOWNLOAD_RATE] = self.maxDownloadRate;
+        }
+
+        // --- Rendition switch counts (mirrors Android; always emitted) ---
+        attrs[KPI_TOTAL_SWITCH_UPS] = @(self.totalSwitchUps);
+        attrs[KPI_TOTAL_SWITCH_DOWNS] = @(self.totalSwitchDowns);
+
+        // --- Distinct rendition count ---
+        attrs[KPI_TOTAL_RENDITIONS] = @((long)self.playedRenditions.count);
 
         return [attrs copy];
     }
@@ -238,6 +305,13 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
     if (self.lastBitrateChangeTimestamp == 0) {
         self.lastBitrateChangeTimestamp = [[NSDate date] timeIntervalSince1970];
     }
+
+    // Seed the initial rendition. Required because NRTrackerAVPlayer's
+    // checkRenditionChange (NRTrackerAVPlayer.m:351-354) silently stamps
+    // lastWidth/Height on the first valid observation WITHOUT firing
+    // CONTENT_RENDITION_CHANGE — so the change-handler path never sees the
+    // initial variant. We seed from CONTENT_START's attributes instead.
+    [self recordCurrentRenditionFromAttributes:attributes];
 }
 
 - (void)handleBufferEndWithAttributes:(NSDictionary *)attributes {
@@ -266,6 +340,47 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
     } else {
         self.hadStartupError = YES;
     }
+}
+
+// Count rendition up/down switches from the player-published "shift" attribute.
+// Fires only on CONTENT_RENDITION_CHANGE. On iOS, shift ("up"/"down") is computed
+// from resolution area in NRTrackerAVPlayer. isEqual: is safe against nil and NSNull
+- (void)handleRenditionChangeWithAttributes:(NSDictionary *)attributes {
+    NSString *shift = attributes[@"shift"];
+    if ([shift isEqual:@"up"]) {
+        self.totalSwitchUps += 1;
+    } else if ([shift isEqual:@"down"]) {
+        self.totalSwitchDowns += 1;
+    }
+    [self recordCurrentRenditionFromAttributes:attributes];
+}
+
+// Add the current rendition (W × H) to the distinct-variants set.
+- (void)recordCurrentRenditionFromAttributes:(NSDictionary *)attributes {
+    NSNumber *w = attributes[@"contentRenditionWidth"];
+    NSNumber *h = attributes[@"contentRenditionHeight"];
+    if (![w isKindOfClass:[NSNumber class]] || ![h isKindOfClass:[NSNumber class]]) return;
+    long width = [w longValue], height = [h longValue];
+    if (width <= 0 || height <= 0) return;
+    [self.playedRenditions addObject:@(width * height)];
+}
+
+// CONTENT_PAUSE: arm the open-segment timer. The closed-segment accumulator
+// is NOT touched here — it gets fed by timeSincePaused on the matching RESUME.
+- (void)handlePause {
+    self.pauseStartTimestamp = [[NSDate date] timeIntervalSince1970];
+}
+
+// CONTENT_RESUME: bank the closed segment using timeSincePaused (already
+// computed by the timeSince table) and disarm the open-segment timer.
+//
+// IMPORTANT: pauseStartTimestamp = 0 MUST happen here.
+- (void)handleResumeWithAttributes:(NSDictionary *)attributes {
+    NSNumber *timeSincePaused = attributes[@"timeSincePaused"];
+    if (timeSincePaused) {
+        self.totalPauseTime += [timeSincePaused longValue];
+    }
+    self.pauseStartTimestamp = 0;
 }
 
 // TIME-WEIGHTED AVERAGE BITRATE ALGORITHM:
@@ -317,6 +432,28 @@ static NSDictionary<NSString *, QoEActionHandler> *sActionHandlers;
     }
 
     self.currentBitrate = bitrate;
+}
+
+- (void)updateDownloadRateFromAttributes:(NSDictionary *)attributes {
+    NSNumber *downloadRateValue = attributes[@"contentNetworkDownloadBitrate"];
+    if (![downloadRateValue isKindOfClass:[NSNumber class]]) {
+        return;
+    }
+
+    long sample = [downloadRateValue longValue];
+    if (sample <= 0) {
+        return;
+    }
+
+    // --- This is a valid reading. Update our 4 tallies. ---
+    self.downloadRateSum += sample;
+    self.downloadRateSampleCount += 1;
+
+    self.minDownloadRate = (self.minDownloadRate == nil)
+        ? @(sample) : @(MIN([self.minDownloadRate longValue], sample));
+
+    self.maxDownloadRate = (self.maxDownloadRate == nil)
+        ? @(sample) : @(MAX([self.maxDownloadRate longValue], sample));
 }
 
 // Called on CONTENT_END to close the final bitrate segment.

--- a/NewRelicVideoCore/NewRelicVideoCore/NRVideoDefs.h
+++ b/NewRelicVideoCore/NewRelicVideoCore/NRVideoDefs.h
@@ -49,7 +49,7 @@
 #define AD_CLICK                    @"AD_CLICK"
 
 #define QOE_AGGREGATE               @"QOE_AGGREGATE"
-#define QOE_AGGREGATE_VERSION       @"1.0.0"
+#define QOE_AGGREGATE_VERSION       @"1.1.0"
 
 // --- Base attribute names (C strings, no prefix) ---
 // These define WHAT is being measured. Each is a raw name without any category prefix.
@@ -62,6 +62,13 @@
 #define ATTR_REBUFFERING_RATIO      "rebufferingRatio"
 #define ATTR_HAD_STARTUP_ERROR      "hadStartupError"
 #define ATTR_HAD_PLAYBACK_ERROR     "hadPlaybackError"
+#define ATTR_AVG_DOWNLOAD_RATE      "avgDownloadRate"
+#define ATTR_MIN_DOWNLOAD_RATE      "minDownloadRate"
+#define ATTR_MAX_DOWNLOAD_RATE      "maxDownloadRate"
+#define ATTR_TOTAL_SWITCH_UPS       "totalSwitchUps"
+#define ATTR_TOTAL_SWITCH_DOWNS     "totalSwitchDowns"
+#define ATTR_TOTAL_PAUSE_TIME       "totalPauseTime"
+#define ATTR_TOTAL_RENDITIONS       "totalRenditions"
 
 // --- Category prefixes (C strings) ---
 // Each category gets its own NRQL namespace prefix.
@@ -80,6 +87,13 @@
 #define KPI_REBUFFERING_RATIO       @QOE_PREFIX ATTR_REBUFFERING_RATIO
 #define KPI_HAD_STARTUP_ERROR       @QOE_PREFIX ATTR_HAD_STARTUP_ERROR
 #define KPI_HAD_PLAYBACK_ERROR      @QOE_PREFIX ATTR_HAD_PLAYBACK_ERROR
+#define KPI_AVG_DOWNLOAD_RATE       @QOE_PREFIX ATTR_AVG_DOWNLOAD_RATE
+#define KPI_MIN_DOWNLOAD_RATE       @QOE_PREFIX ATTR_MIN_DOWNLOAD_RATE
+#define KPI_MAX_DOWNLOAD_RATE       @QOE_PREFIX ATTR_MAX_DOWNLOAD_RATE
+#define KPI_TOTAL_SWITCH_UPS        @QOE_PREFIX ATTR_TOTAL_SWITCH_UPS
+#define KPI_TOTAL_SWITCH_DOWNS      @QOE_PREFIX ATTR_TOTAL_SWITCH_DOWNS
+#define KPI_TOTAL_PAUSE_TIME        @QOE_PREFIX ATTR_TOTAL_PAUSE_TIME
+#define KPI_TOTAL_RENDITIONS        @QOE_PREFIX ATTR_TOTAL_RENDITIONS
 
 // --- Centralized list of all QoE KPI attribute keys ---
 // When adding a new KPI_* macro above, also add it to this array.
@@ -96,7 +110,14 @@ static inline NSArray<NSString *> *NRVAAllKPIKeys(void) {
             KPI_TOTAL_REBUFFERING_TIME,
             KPI_REBUFFERING_RATIO,
             KPI_HAD_STARTUP_ERROR,
-            KPI_HAD_PLAYBACK_ERROR
+            KPI_HAD_PLAYBACK_ERROR,
+            KPI_AVG_DOWNLOAD_RATE,
+            KPI_MIN_DOWNLOAD_RATE,
+            KPI_MAX_DOWNLOAD_RATE,
+            KPI_TOTAL_SWITCH_UPS,
+            KPI_TOTAL_SWITCH_DOWNS,
+            KPI_TOTAL_PAUSE_TIME,
+            KPI_TOTAL_RENDITIONS
         ];
     });
     return keys;

--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
@@ -292,7 +292,10 @@
         if ([action isEqualToString:CONTENT_START] && self.qoeAggregator) {
             [self.qoeAggregator setTotalPreRollAdTime:self.totalPreRollAdTime];
         }
-        [self.qoeAggregator processAction:action attributes:attributes isPlaying:self.state.isPlaying];
+        // A CONTENT_PAUSE during a break is the player paused for the ad, not a user pause.
+        BOOL adBreakActive = [self.linkedTracker isKindOfClass:[NRVideoTracker class]]
+                             && ((NRVideoTracker *)self.linkedTracker).state.isAdBreak;
+        [self.qoeAggregator processAction:action attributes:attributes isPlaying:self.state.isPlaying adBreakActive:adBreakActive];
         self.lastContentEventAttributes = [attributes copy];
     }
 

--- a/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Tracker/NRVideoTracker.m
@@ -935,24 +935,38 @@
     // Dirty check: Only send if KPI attributes have changed
     if ([self qoeAttributesChangedFrom:self.lastSentQoEAttributes to:qoeEvent]) {
         self.lastSentQoEAttributes = qoeEvent;
-        NRVA_DEBUG_LOG(@"[QOE_AGGREGATE] => {\n"
-                       "  startupTime          = %@\n"
-                       "  peakBitrate          = %@\n"
-                       "  averageBitrate       = %@\n"
-                       "  totalPlaytime        = %@\n"
-                       "  totalRebufferingTime = %@\n"
-                       "  rebufferingRatio     = %@\n"
-                       "  hadStartupError      = %@\n"
-                       "  hadPlaybackError     = %@\n"
+                NRVA_DEBUG_LOG(@"[QOE_AGGREGATE] => {\n"
+                       "  startupTime           = %@\n"
+                       "  peakBitrate           = %@\n"
+                       "  averageBitrate        = %@\n"
+                       "  totalPlaytime         = %@\n"
+                       "  totalRebufferingTime  = %@\n"
+                       "  rebufferingRatio      = %@\n"
+                       "  hadStartupError       = %@\n"
+                       "  hadPlaybackError      = %@\n"
+                       "  avgDownloadRate       = %@\n"
+                       "  minDownloadRate       = %@\n"
+                       "  maxDownloadRate       = %@\n"
+                       "  totalSwitchUps        = %@\n"
+                       "  totalSwitchDowns      = %@\n"
+                       "  totalPauseTime        = %@\n"
+                       "  totalRenditions       = %@\n"
                        "}",
-                       qoeEvent[@"startupTime"]          ?: @"(nil)",
-                       qoeEvent[@"peakBitrate"]          ?: @"(nil)",
-                       qoeEvent[@"averageBitrate"]        ?: @"(nil)",
-                       qoeEvent[@"totalPlaytime"]         ?: @"(nil)",
-                       qoeEvent[@"totalRebufferingTime"]  ?: @"(nil)",
-                       qoeEvent[@"rebufferingRatio"]      ?: @"(nil)",
-                       qoeEvent[@"hadStartupError"]       ?: @"(nil)",
-                       qoeEvent[@"hadPlaybackError"]      ?: @"(nil)");
+                       qoeEvent[@"startupTime"]            ?: @"(nil)",
+                       qoeEvent[@"peakBitrate"]            ?: @"(nil)",
+                       qoeEvent[@"averageBitrate"]         ?: @"(nil)",
+                       qoeEvent[@"totalPlaytime"]          ?: @"(nil)",
+                       qoeEvent[@"totalRebufferingTime"]   ?: @"(nil)",
+                       qoeEvent[@"rebufferingRatio"]       ?: @"(nil)",
+                       qoeEvent[@"hadStartupError"]        ?: @"(nil)",
+                       qoeEvent[@"hadPlaybackError"]       ?: @"(nil)",
+                       qoeEvent[@"avgDownloadRate"]        ?: @"(nil)",
+                       qoeEvent[@"minDownloadRate"]        ?: @"(nil)",
+                       qoeEvent[@"maxDownloadRate"]        ?: @"(nil)",
+                       qoeEvent[@"totalSwitchUps"]         ?: @"(nil)",
+                       qoeEvent[@"totalSwitchDowns"]       ?: @"(nil)",
+                       qoeEvent[@"totalPauseTime"]         ?: @"(nil)",
+                       qoeEvent[@"totalRenditions"]        ?: @"(nil)");
         return qoeEvent;
     }
 

--- a/NewRelicVideoCore/NewRelicVideoCoreTests/NRQoEAggregatorTests.m
+++ b/NewRelicVideoCore/NewRelicVideoCoreTests/NRQoEAggregatorTests.m
@@ -544,4 +544,510 @@
     XCTAssertNil(result[KPI_PEAK_BITRATE], @"Negative bitrate should not be tracked");
 }
 
+#pragma mark - Download Rate
+
+- (void)testAvgDownloadRateIsArithmeticMean {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000), @"contentNetworkDownloadBitrate": @(2000000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(4000000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(6000000)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    // (2M + 4M + 6M) / 3 = 4M — arithmetic mean of samples, NOT time-weighted
+    XCTAssertEqualObjects(result[KPI_AVG_DOWNLOAD_RATE], @(4000000));
+}
+
+- (void)testMinMaxDownloadRate {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000), @"contentNetworkDownloadBitrate": @(3000000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(6000000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(2000000)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_MIN_DOWNLOAD_RATE], @(2000000));
+    XCTAssertEqualObjects(result[KPI_MAX_DOWNLOAD_RATE], @(6000000));
+}
+
+- (void)testDownloadRateAbsentWhenNoSamples {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertNil(result[KPI_AVG_DOWNLOAD_RATE], @"Absent when no download rate sampled");
+    XCTAssertNil(result[KPI_MIN_DOWNLOAD_RATE]);
+    XCTAssertNil(result[KPI_MAX_DOWNLOAD_RATE]);
+}
+
+- (void)testDownloadRateIgnoresZeroNegativeAndNull {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000), @"contentNetworkDownloadBitrate": @(0)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(-500)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": [NSNull null]}
+                         isPlaying:YES];
+    // Only this one is a valid sample
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(5000000)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_AVG_DOWNLOAD_RATE], @(5000000));
+    XCTAssertEqualObjects(result[KPI_MIN_DOWNLOAD_RATE], @(5000000));
+    XCTAssertEqualObjects(result[KPI_MAX_DOWNLOAD_RATE], @(5000000));
+}
+
+- (void)testAvgDownloadRateRoundsToNearestInteger {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000), @"contentNetworkDownloadBitrate": @(1000000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(1000001)}
+                         isPlaying:YES];
+    // (1000000 + 1000001) / 2 = 1000000.5 → rounds to 1000001
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_AVG_DOWNLOAD_RATE], @(1000001));
+}
+
+- (void)testDownloadRateResetsBetweenSessions {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000), @"contentNetworkDownloadBitrate": @(9000000)}
+                         isPlaying:YES];
+    [self.aggregator reset];
+
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertNil(result[KPI_AVG_DOWNLOAD_RATE], @"Should clear after reset");
+    XCTAssertNil(result[KPI_MIN_DOWNLOAD_RATE], @"min must not leak across sessions");
+    XCTAssertNil(result[KPI_MAX_DOWNLOAD_RATE], @"max must not leak across sessions");
+}
+
+#pragma mark - Rendition Switches
+
+- (void)testSwitchUpsCounted {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE
+                        attributes:@{@"shift": @"up"}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE
+                        attributes:@{@"shift": @"up"}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_UPS], @(2));
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_DOWNS], @(0));
+}
+
+- (void)testSwitchDownsCounted {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE
+                        attributes:@{@"shift": @"down"}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_DOWNS], @(1));
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_UPS], @(0));
+}
+
+- (void)testMixedSwitchSequence {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+    // up, down, down, up, up  → 3 ups, 2 downs
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{@"shift": @"up"} isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{@"shift": @"down"} isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{@"shift": @"down"} isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{@"shift": @"up"} isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{@"shift": @"up"} isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_UPS], @(3));
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_DOWNS], @(2));
+}
+
+- (void)testSwitchIgnoresMissingNullAndUnknownShift {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+    // No shift key at all
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{} isPlaying:YES];
+    // shift is NSNull
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{@"shift": [NSNull null]} isPlaying:YES];
+    // shift is an unrecognized value
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{@"shift": @"sideways"} isPlaying:YES];
+    // One valid "up" to prove the handler still works after the bad ones
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{@"shift": @"up"} isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_UPS], @(1));
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_DOWNS], @(0));
+}
+
+- (void)testSwitchCountsEmittedAsZeroWhenNoChanges {
+    // Counts are always emitted (mirrors Android), reading 0 before any rendition change.
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_UPS], @(0));
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_DOWNS], @(0));
+}
+
+- (void)testSwitchCountsResetBetweenSessions {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START attributes:@{@"timeSinceRequested": @(1000)} isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{@"shift": @"up"} isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{@"shift": @"down"} isPlaying:YES];
+    [self.aggregator reset];
+
+    // New session: counts must start fresh at 0
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_UPS], @(0), @"ups must not leak across sessions");
+    XCTAssertEqualObjects(result[KPI_TOTAL_SWITCH_DOWNS], @(0), @"downs must not leak across sessions");
+}
+
+#pragma mark - Total Pause Time
+
+// Helper: drive the aggregator into a "post-CONTENT_START" steady state so each
+// pause-time test starts from the same baseline.
+- (void)beginPauseTestSession {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+}
+
+// Briefing case 1 — closed-only.
+// pause → resume → assert KPI equals timeSincePaused exactly.
+- (void)testTotalPauseTimeFromClosedSegmentOnly {
+    [self beginPauseTestSession];
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(2500)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_PAUSE_TIME], @(2500),
+                          @"Closed segment must equal timeSincePaused exactly — "
+                          @"no clock observation should leak in.");
+}
+
+// Briefing case 2 — mid-pause snapshot.
+// pause → wait → snapshot → assert open-segment delta is included AND that
+// the underlying accumulator was not mutated (catches the "local var, not self"
+// gotcha from the briefing).
+- (void)testTotalPauseTimeIncludesOpenSegmentMidPause {
+    [self beginPauseTestSession];
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+    [NSThread sleepForTimeInterval:0.05];
+
+    NSDictionary *snap = [self.aggregator generateAggregateAttributes];
+    long emitted = [snap[KPI_TOTAL_PAUSE_TIME] longValue];
+    XCTAssertGreaterThanOrEqual(emitted, 30,
+                                @"Open segment (~50ms) must be visible in mid-pause emit");
+    XCTAssertLessThan(emitted, 500, @"sanity bound — emit should be ~50ms, well under 500ms");
+
+    // KVC into the private accumulator: snapshot must NOT have written to self.
+    long banked = [[self.aggregator valueForKey:@"totalPauseTime"] longValue];
+    XCTAssertEqual(banked, 0L,
+                   @"Open-segment branch must use a local var. If self.totalPauseTime "
+                   @"got mutated here, the next RESUME will double-count.");
+}
+
+// Briefing case 3 — no double count.
+// pause → snapshot mid-pause → resume → snapshot → assert resume value is
+// exactly timeSincePaused. If the open-segment branch had leaked into self,
+// the post-resume value would be ~2500 + ~50ms = ~2550. The point of this
+// test is to fail fast if that regression is ever introduced.
+- (void)testTotalPauseTimeNoDoubleCountAfterResume {
+    [self beginPauseTestSession];
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+    [NSThread sleepForTimeInterval:0.05];
+
+    // Mid-pause snapshot — the trap. Discarded; we only care about the side effect.
+    (void)[self.aggregator generateAggregateAttributes];
+
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(2500)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_PAUSE_TIME], @(2500),
+                          @"Post-resume value must equal timeSincePaused exactly. "
+                          @"Any leftover from the mid-pause snapshot would double-count.");
+}
+
+// Multiple pause-resume cycles must accumulate, not overwrite.
+- (void)testTotalPauseTimeAccumulatesAcrossMultipleCycles {
+    [self beginPauseTestSession];
+
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(1000)}
+                         isPlaying:YES];
+
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(500)}
+                         isPlaying:YES];
+
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(750)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_PAUSE_TIME], @(2250),
+                          @"Three cycles of 1000+500+750 must sum to 2250");
+}
+
+// Pre-CONTENT_START "pauses" (e.g. weird player flow) must not appear in the
+// emitted dict — same gate as totalRebufferingTime.
+- (void)testTotalPauseTimeAbsentBeforeContentStart {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(1000)}
+                         isPlaying:NO];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertNil(result[KPI_TOTAL_PAUSE_TIME],
+                 @"Pre-start pauses must be absent from the emit (hasReceivedStart gate)");
+}
+
+// reset() must clear both the closed accumulator AND the open-segment timer,
+// otherwise pause state from the previous session leaks into the new one.
+- (void)testResetClearsBothPauseFields {
+    [self beginPauseTestSession];
+
+    // Build up some closed-segment state and leave an open segment armed.
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(1234)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+
+    [self.aggregator reset];
+
+    XCTAssertEqual(0L, [[self.aggregator valueForKey:@"totalPauseTime"] longValue],
+                   @"reset must clear the closed-segment accumulator");
+    XCTAssertEqualWithAccuracy(0.0,
+                               [[self.aggregator valueForKey:@"pauseStartTimestamp"] doubleValue],
+                               0.0001,
+                               @"reset must disarm the open-segment timer — "
+                               @"otherwise the next emit would add a huge bogus delta.");
+}
+
+// CONTENT_RESUME without timeSincePaused in the dict must not crash and must
+// not poison the accumulator. The pauseStartTimestamp must still be disarmed
+// so the next snapshot doesn't keep adding a stale open segment.
+- (void)testTotalPauseTimeHandlesMissingTimeSincePausedAttribute {
+    [self beginPauseTestSession];
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_RESUME attributes:@{} isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_PAUSE_TIME], @(0),
+                          @"Missing timeSincePaused must be a graceful no-op (not a crash)");
+    XCTAssertEqualWithAccuracy(0.0,
+                               [[self.aggregator valueForKey:@"pauseStartTimestamp"] doubleValue],
+                               0.0001,
+                               @"Even without timeSincePaused, RESUME must disarm the timer.");
+}
+
+// Successive mid-pause snapshots during a long pause must report monotonically
+// increasing values. This is the live-harvest case the briefing's "verify
+// before declaring done" step calls out.
+- (void)testTotalPauseTimeGrowsMonotonicallyAcrossMidPauseHarvests {
+    [self beginPauseTestSession];
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+
+    [NSThread sleepForTimeInterval:0.03];
+    long snap1 = [[self.aggregator generateAggregateAttributes][KPI_TOTAL_PAUSE_TIME] longValue];
+
+    [NSThread sleepForTimeInterval:0.05];
+    long snap2 = [[self.aggregator generateAggregateAttributes][KPI_TOTAL_PAUSE_TIME] longValue];
+
+    [NSThread sleepForTimeInterval:0.05];
+    long snap3 = [[self.aggregator generateAggregateAttributes][KPI_TOTAL_PAUSE_TIME] longValue];
+
+    XCTAssertGreaterThan(snap2, snap1, @"second mid-pause snapshot must be > first");
+    XCTAssertGreaterThan(snap3, snap2, @"third mid-pause snapshot must be > second");
+}
+
+#pragma mark - Total Renditions
+
+// Helper: send a CONTENT_RENDITION_CHANGE with the given W/H. This is the
+// real path the set is fed from (CONTENT_HEARTBEAT does NOT touch the
+// set — rendition tracking is event-driven, not sample-driven).
+- (void)observeRenditionWidth:(long)width height:(long)height {
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE
+                        attributes:@{@"contentRenditionWidth":  @(width),
+                                     @"contentRenditionHeight": @(height)}
+                         isPlaying:YES];
+}
+
+// 3 distinct W×H pairs → count of 3.
+- (void)testTotalRenditionsCountsDistinctValues {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000),
+                                     @"contentRenditionWidth":  @(640),
+                                     @"contentRenditionHeight": @(360)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE
+                        attributes:@{@"shift": @"up",
+                                     @"contentRenditionWidth":  @(1280),
+                                     @"contentRenditionHeight": @(720)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE
+                        attributes:@{@"shift": @"up",
+                                     @"contentRenditionWidth":  @(1920),
+                                     @"contentRenditionHeight": @(1080)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_RENDITIONS], @(3),
+                          @"Three distinct W×H pairs should count as 3");
+}
+
+// Same W×H repeated → count of 1 (set dedup).
+- (void)testTotalRenditionsDedupsRepeatedValues {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000),
+                                     @"contentRenditionWidth":  @(1280),
+                                     @"contentRenditionHeight": @(720)}
+                         isPlaying:YES];
+    for (int i = 0; i < 10; i++) {
+        [self.aggregator processAction:CONTENT_RENDITION_CHANGE
+                            attributes:@{@"contentRenditionWidth":  @(1280),
+                                         @"contentRenditionHeight": @(720)}
+                             isPlaying:YES];
+    }
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_RENDITIONS], @(1),
+                          @"10 observations of the same W×H must count as 1");
+}
+
+// Initial rendition seeded at CONTENT_START — no RENDITION_CHANGE needed.
+// This is the iOS-specific fix: NRTrackerAVPlayer doesn't fire the change
+// event for the initial variant (NRTrackerAVPlayer.m:351-354).
+- (void)testTotalRenditionsSeedsFromContentStart {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000),
+                                     @"contentRenditionWidth":  @(1920),
+                                     @"contentRenditionHeight": @(1080)}
+                         isPlaying:YES];
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_RENDITIONS], @(1),
+                          @"CONTENT_START's W×H must seed the set without "
+                          @"requiring a CONTENT_RENDITION_CHANGE event.");
+}
+
+// Invalid values must never enter the set.
+- (void)testTotalRenditionsIgnoresInvalidValues {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+
+    // 0/negative
+    [self observeRenditionWidth:0 height:0];
+    [self observeRenditionWidth:-1 height:1080];
+    [self observeRenditionWidth:1920 height:-1];
+
+    // NSNull
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE
+                        attributes:@{@"contentRenditionWidth":  [NSNull null],
+                                     @"contentRenditionHeight": @(1080)}
+                         isPlaying:YES];
+
+    // Missing
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE attributes:@{} isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_RENDITIONS], @(0),
+                          @"None of the invalid inputs should enter the set");
+}
+
+// Always emitted, even at 0 (per spec §4 "Always (0 valid)").
+- (void)testTotalRenditionsEmittedWhenZero {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertNotNil(result[KPI_TOTAL_RENDITIONS],
+                    @"totalRenditions must be present even pre-CONTENT_START");
+    XCTAssertEqualObjects(result[KPI_TOTAL_RENDITIONS], @(0),
+                          @"Pre-start value must be 0, not absent");
+}
+
+// reset() clears the set so a new session doesn't inherit prior renditions.
+- (void)testResetClearsPlayedRenditions {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000),
+                                     @"contentRenditionWidth":  @(640),
+                                     @"contentRenditionHeight": @(360)}
+                         isPlaying:YES];
+    [self observeRenditionWidth:1280 height:720];
+    [self observeRenditionWidth:1920 height:1080];
+    XCTAssertEqual(3u,
+                   [(NSSet *)[self.aggregator valueForKey:@"playedRenditions"] count]);
+
+    [self.aggregator reset];
+    XCTAssertEqual(0u,
+                   [(NSSet *)[self.aggregator valueForKey:@"playedRenditions"] count],
+                   @"reset must empty the set");
+}
+
+// Same W×H delivered via different event types must collide in the set —
+// 1280×720 from CONTENT_START and from CONTENT_RENDITION_CHANGE share a hash.
+- (void)testTotalRenditionsDedupsAcrossEventTypes {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000),
+                                     @"contentRenditionWidth":  @(1280),
+                                     @"contentRenditionHeight": @(720)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_RENDITION_CHANGE
+                        attributes:@{@"shift": @"none",
+                                     @"contentRenditionWidth":  @(1280),
+                                     @"contentRenditionHeight": @(720)}
+                         isPlaying:YES];
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_RENDITIONS], @(1),
+                          @"Same W×H seen via two different event types must dedupe");
+}
+
 @end

--- a/NewRelicVideoCore/NewRelicVideoCoreTests/NRQoEAggregatorTests.m
+++ b/NewRelicVideoCore/NewRelicVideoCoreTests/NRQoEAggregatorTests.m
@@ -905,6 +905,70 @@
     XCTAssertGreaterThan(snap3, snap2, @"third mid-pause snapshot must be > second");
 }
 
+#pragma mark - Ad-Break Pause Exclusion
+
+// A content pause that brackets an ad break (player paused for the ad) must NOT
+// be counted in totalPauseTime. isAdBreak is true at CONTENT_PAUSE (adBreakActive:YES)
+// but already cleared by CONTENT_RESUME (adBreakActive:NO) — the fix keys off the
+// armed timer, so the closed segment is skipped.
+- (void)testAdBreakPauseExcludedFromTotalPauseTime {
+    [self beginPauseTestSession];
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO adBreakActive:YES];
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(30000)}
+                         isPlaying:YES adBreakActive:NO];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_PAUSE_TIME], @(0),
+                          @"Ad-break pause must be excluded from totalPauseTime");
+}
+
+// A real user pause still counts; an ad-break pause in the same view is excluded.
+// Proves the gate is selective, not a blanket suppression.
+- (void)testUserPauseCountsButAdBreakPauseDoesNot {
+    [self beginPauseTestSession];
+    // Real user pause — counts.
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO adBreakActive:NO];
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(5000)}
+                         isPlaying:YES adBreakActive:NO];
+    // Ad-break pause — excluded.
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO adBreakActive:YES];
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(30000)}
+                         isPlaying:YES adBreakActive:NO];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_PAUSE_TIME], @(5000),
+                          @"Only the user pause counts; ad-break pause excluded");
+}
+
+// The 3-arg processAction: (no adBreakActive) must still count a normal pause —
+// backward-compatible default of adBreakActive:NO.
+- (void)testThreeArgProcessActionStillCountsPause {
+    [self beginPauseTestSession];
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_RESUME
+                        attributes:@{@"timeSincePaused": @(4000)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_TOTAL_PAUSE_TIME], @(4000),
+                          @"3-arg API must behave as a non-ad-break (user) pause");
+}
+
+// A mid-ad-break harvest snapshot must not add an open segment for an ad-break pause
+// (the open-segment branch keys off pauseStartTimestamp, which was never armed).
+- (void)testAdBreakPauseNotInMidBreakSnapshot {
+    [self beginPauseTestSession];
+    [self.aggregator processAction:CONTENT_PAUSE attributes:@{} isPlaying:NO adBreakActive:YES];
+    [NSThread sleepForTimeInterval:0.05];
+
+    NSDictionary *snap = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(snap[KPI_TOTAL_PAUSE_TIME], @(0),
+                          @"Open ad-break pause must not appear in a mid-break snapshot");
+}
+
 #pragma mark - Download Rate Dedup
 
 // Stale-sample dedup. AVPlayer's accessLog.events.lastObject keeps returning

--- a/NewRelicVideoCore/NewRelicVideoCoreTests/NRQoEAggregatorTests.m
+++ b/NewRelicVideoCore/NewRelicVideoCoreTests/NRQoEAggregatorTests.m
@@ -905,6 +905,94 @@
     XCTAssertGreaterThan(snap3, snap2, @"third mid-pause snapshot must be > second");
 }
 
+#pragma mark - Download Rate Dedup
+
+// Stale-sample dedup. AVPlayer's accessLog.events.lastObject keeps returning
+// the same entry between real network events, so every-event observation
+// would otherwise count the same throughput value over and over and bias the
+// average toward whichever rate was sticky during the longest idle window.
+- (void)testDownloadRateSkipsConsecutiveDuplicates {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+    // 5 Mbps reported across 10 events — only the first is a real new download.
+    for (int i = 0; i < 10; i++) {
+        [self.aggregator processAction:CONTENT_HEARTBEAT
+                            attributes:@{@"contentNetworkDownloadBitrate": @(5000000)}
+                             isPlaying:YES];
+    }
+    // 7 Mbps reported across 5 events — only the first is a real new download.
+    for (int i = 0; i < 5; i++) {
+        [self.aggregator processAction:CONTENT_HEARTBEAT
+                            attributes:@{@"contentNetworkDownloadBitrate": @(7000000)}
+                             isPlaying:YES];
+    }
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    // True mean over the two distinct events: (5M + 7M) / 2 = 6M.
+    // Without dedup this would skew toward 5M because of the 10:5 weighting.
+    XCTAssertEqualObjects(result[KPI_AVG_DOWNLOAD_RATE], @(6000000),
+                          @"Stale repeats must be skipped — average reflects "
+                          @"distinct samples, not event count.");
+    XCTAssertEqualObjects(result[KPI_MIN_DOWNLOAD_RATE], @(5000000));
+    XCTAssertEqualObjects(result[KPI_MAX_DOWNLOAD_RATE], @(7000000));
+}
+
+// A → B → A pattern: dedup is consecutive only. If the rate genuinely returns
+// to a previous value (real new download that happens to clock the same), it
+// must count again — the access log entry is fresh, the value is just equal.
+- (void)testDownloadRateAcceptsNonConsecutiveDuplicates {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(3000000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(7000000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(3000000)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    // 3 distinct events: (3M + 7M + 3M) / 3 ≈ 4_333_333
+    XCTAssertEqualObjects(result[KPI_AVG_DOWNLOAD_RATE], @(4333333),
+                          @"A→B→A pattern: the second 3M is a fresh event, must count");
+}
+
+// Reset clears lastDownloadRateSample — a fresh session must accept the same
+// value the previous session ended on as a brand-new sample.
+- (void)testResetClearsLastDownloadRateSample {
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(5000000)}
+                         isPlaying:YES];
+
+    [self.aggregator reset];
+    XCTAssertNil([self.aggregator valueForKey:@"lastDownloadRateSample"],
+                 @"reset must clear lastDownloadRateSample");
+
+    // New session ending in the SAME 5M value — must count, not be deduped
+    // against the stale lastDownloadRateSample from before the reset.
+    [self.aggregator processAction:CONTENT_REQUEST attributes:@{} isPlaying:NO];
+    [self.aggregator processAction:CONTENT_START
+                        attributes:@{@"timeSinceRequested": @(1000)}
+                         isPlaying:YES];
+    [self.aggregator processAction:CONTENT_HEARTBEAT
+                        attributes:@{@"contentNetworkDownloadBitrate": @(5000000)}
+                         isPlaying:YES];
+
+    NSDictionary *result = [self.aggregator generateAggregateAttributes];
+    XCTAssertEqualObjects(result[KPI_AVG_DOWNLOAD_RATE], @(5000000),
+                          @"Post-reset session must accept the value as a new sample");
+}
+
 #pragma mark - Total Renditions
 
 // Helper: send a CONTENT_RENDITION_CHANGE with the given W/H. This is the

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The New Relic Video Agent for iOS & tvOS provides comprehensive video analytics 
 ## Features
 
 - **Automatic Event Detection** — Captures AVPlayer lifecycle events automatically without manual instrumentation
-- **QoE Metrics** — Quality of Experience aggregation for startup time, buffering ratio, bitrate, and playback errors
+- **QoE Metrics** — Per-session aggregate covering startup time, rebuffering, bitrate (peak / average / per-sample download rate min / max / mean), adaptive-bitrate behavior (rendition switch counts, distinct renditions seen), pause time, and playback errors. See [DATAMODEL.md](./DATAMODEL.md#qoe_aggregate-attributes) for the full attribute reference.
 - **Event Segregation** — Organized event types: `VideoAction`, `VideoAdAction`, `VideoErrorAction`, `VideoCustomAction`
 - **IMA Ads Support** — Built-in Google IMA SDK ad tracking via dedicated ad tracker
 - **tvOS Support** — Auto-detection of Apple TV with optimized harvest cycles


### PR DESCRIPTION
Adds 7 new KPIs to the `QOE_AGGREGATE` event and bumps `qoeAggregateVersion` to `1.1.0` for cross-platform parity with video-agent-android.

| KPI | Type | What it measures |
|---|---|---|
| `avgDownloadRate` | Long (bps) | Mean network download throughput across distinct samples |
| `minDownloadRate` | Long (bps) | Lowest download throughput observed (omitted when no sample) |
| `maxDownloadRate` | Long (bps) | Highest download throughput observed (omitted when no sample) |
| `totalSwitchUps` | Long | Count of CONTENT_RENDITION_CHANGE events where quality went up |
| `totalSwitchDowns` | Long | Count of CONTENT_RENDITION_CHANGE events where quality went down |
| `totalPauseTime` | Long (ms) | Total time the user spent paused this session |
| `totalRenditions` | Long | Distinct video renditions (W×H pairs) observed this session |


## How it's wired

All 7 KPIs live entirely on `NRQoEAggregator` — no new tracker-side state. The aggregator observes the assembled attribute dict that already flows through `processAction:`, mirroring the existing pattern for totalRebufferingTime.

**Three design choices worth knowing:**

1. **avgDownloadRate skips consecutive duplicate samples.** AVPlayer's `accessLog.events.lastObject` returns the same entry between real network events, so naïve every-event observation would bias the mean toward whichever rate was sticky during the longest idle window. The aggregator only accumulates on change — true mean over distinct download events.

2. **totalPauseTime consumes `timeSincePaused` from the existing timeSince table** instead of running its own clock. Mid-pause harvest still reports correctly via an open-segment snapshot in generateAggregateAttributes — written to a local var, never back into `self.totalPauseTime`, so the matching RESUME doesn't double-count.

3. **totalRenditions keys on width × height, not bitrate.** Pixel-area keying is robust to streams that label distinct resolution variants with the same bitrate. Initial rendition is seeded at CONTENT_START because `NRTrackerAVPlayer.checkRenditionChange` (lines 351-354) silently stamps the first observation without firing CONTENT_RENDITION_CHANGE.

**Auto-wired:**
- Dirty check iterates NRVAAllKPIKeys(), so adding entries there picks up new KPIs for duplicate suppression with zero comparator changes.
- buildQoeEvent does addEntriesFromDictionary, so any new KPI reaches the wire automatically.
- [aggregator reset] is already called on sendEnd, so per-view reset works for free.


## Test plan

- [x] Unit: 61/61 passing (was 31; +30 new)
- [x] Spec-required cases for totalPauseTime: closed-only, mid-pause snapshot, no-double-count after resume
- [x] Distinct-count / dedup / seed-from-start / invalid-rejected for totalRenditions
- [x] Consecutive-duplicate skip + non-consecutive accept for avgDownloadRate
- [x] Reset coverage — every new accumulator clears on [aggregator reset]
- [x] New keys present in NRVA_DEBUG_LOG at harvest time
- [x] Manual: launch Examples/iOS/SimplePlayerWithAds, pause + resume + change quality, confirm all 7 KPIs surface in the QOE_AGGREGATE event
- [x] NRQL parity check against Android sample app for the same scenario