### PR TITLE
chore: trigger release-notes-docs-pr after release creation

### DIFF
--- a/.github/workflows/ios-publish.yml
+++ b/.github/workflows/ios-publish.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   publish:
@@ -339,6 +340,14 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger Release Notes Docs PR
+        if: env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release-notes-docs-pr.yml --ref master --field tag="v${{ steps.get_version.outputs.version }}" --field dry_run=false
+          echo "Triggered release-notes-docs-pr.yml for v${{ steps.get_version.outputs.version }}"
 
       - name: Verify publication
         run: |


### PR DESCRIPTION
## Summary

GitHub Actions does not fire downstream workflow triggers (like `release: published`) for events created by `GITHUB_TOKEN`. This means `release-notes-docs-pr.yml` never auto-fires after an automated release.

**Fix:** Add `actions: write` permission and explicitly dispatch `release-notes-docs-pr.yml` via `gh workflow run` after the GitHub release is created in `ios-publish.yml`.

## Test plan

- [ ] Merge and trigger a release — verify `release-notes-docs-pr.yml` runs automatically
- [ ] Alternatively, manually create a release and confirm the docs PR workflow is triggered