### PR TITLE
fix: Multiple Device UUID per viewId

### DIFF
--- a/NewRelicVideoCore/NewRelicVideoCore/Auth/NRVATokenManager.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Auth/NRVATokenManager.m
@@ -10,6 +10,7 @@
 #import "NRVAVideoConfiguration.h"
 #import "NRVAUtils.h"
 #import "NRVALog.h"
+#import "NRVADeviceInformation.h"
 
 #import <UIKit/UIKit.h>
 
@@ -278,7 +279,7 @@ static const NSTimeInterval kNRVA_READ_TIMEOUT = 30.0;    // 30 seconds for TV n
     NSString *architecture = [self getArchitecture];
     NSString *agentName = @"NewRelic-VideoAgent-iOS";
     NSString *agentVersion = @"4.2.0";
-    NSString *deviceId = [NRVAUtils generateSessionId]; // Use session ID as device identifier
+    NSString *deviceId = [NRVADeviceInformation sharedInstance].deviceId;
     NSString *manufacturer = @"Apple";
     
     // Device metadata

--- a/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAOptimizedHttpClient.m
+++ b/NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAOptimizedHttpClient.m
@@ -11,6 +11,7 @@
 #import "NRVATokenManager.h"
 #import "NRVAUtils.h"
 #import "NRVALog.h"
+#import "NRVADeviceInformation.h"
 
 static const int kMaxRetryAttempts = 3;
 
@@ -219,7 +220,7 @@ static const int kMaxRetryAttempts = 3;
     NSString *architecture = [self getArchitecture];
     NSString *agentName = @"NewRelic-VideoAgent-iOS";
     NSString *agentVersion = @"4.2.0";
-    NSString *deviceId = [NRVAUtils generateSessionId];
+    NSString *deviceId = [NRVADeviceInformation sharedInstance].deviceId;
     NSString *manufacturer = @"Apple";
     
     NSDictionary *deviceMetadata = @{


### PR DESCRIPTION
### Bug
iOS was generating a new device identifier on every harvest/token request instead of reusing one per device, unlike Android/FireTV/Roku which cache a stable per-device ID for the life of the process.

### Root Cause
`NRVATokenManager.m` and `NRVAOptimizedHttpClient.m` both built the `deviceId` field from `[NRVAUtils generateSessionId]`, which wraps `[[NSProcessInfo processInfo] globallyUniqueString]` — a fresh UUID on every call. The correct singleton, `NRVADeviceInformation.sharedInstance.deviceId` (cached, built from `identifierForVendor`), already existed in the codebase but wasn't wired into these two payload builders.

### Fix
Point both call sites at `[NRVADeviceInformation sharedInstance].deviceId` instead, matching the pattern Android already uses (`deviceInfo.getDeviceId()` off its own cached singleton). Two-line change, no new abstractions.

### Files Changed
- `NewRelicVideoCore/NewRelicVideoCore/Auth/NRVATokenManager.m`
- `NewRelicVideoCore/NewRelicVideoCore/Harvest/NRVAOptimizedHttpClient.m`

### Impact
viewIds will now correlate to a single, stable device UUID on iOS, matching cross-platform behavior.