### PR TITLE
docs: add harvest cycle configuration documentation

### DIFF
--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -48,7 +48,6 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | contentSegmentDownloadBitrate   | Observed Bitrate: The actual, empirical throughput measured in bits per second across all downloaded media.                                         |
 | contentNetworkDownloadBitrate   | The actual download throughput in bits per second.                                                                                                 |
 | contentRenditionName     | Name of the rendition (e.g., 1080p).                                                                                                               |
-| contentRenditionBitrate  | Target Bitrate of the rendition.                                                                                                                   |
 | contentRenditionHeight   | Rendition actual Height (before re-scaling).                                                                                                       |
 | contentRenditionWidth    | Rendition actual Width (before re-scaling).                                                                                                        |
 | contentDuration          | Duration of the video, in ms.                                                                                                                      |
@@ -64,7 +63,7 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | contentFps               | Current FPS (Frames per second).                                                                                                                   |
 | isBackgroundEvent        | If the player is hidden by another window.                                                                                                         |
 | totalAdPlaytime          | Total time ad is played for this video session.                                                                                                    |
-| elapsedTime              | Time that has passed since the last event.                                                                                                         |
+| elapsedTime              | Active content watched between two consecutive heartbeats, in milliseconds.                                                                                                         |
 | bufferType               | When buffer starts, i.e., initial, seek, pause & connection.                                                                                       |
 | asn                      | Autonomous System Number: a unique number identifying a group of IP networks that serves the content to the end user.                              |
 | asnLatitude              | The latitude of the geographic center of the postal code where the Autonomous System Network is registered. This is not the end user's latitude.   |
@@ -74,6 +73,18 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | instrumentation.provider | Player/agent name.                                                                                                                                 |
 | instrumentation.name     | Name of the instrumentation collecting the data.                                                                                                   |
 | instrumentation.version  | Agent’s version.                                                                                                                                   |
+
+| timeSinceRequested       | Time (in milliseconds) since the video was requested.                                                                                              |
+| timeSinceStarted         | Time (in milliseconds) since the video started playing.                                                                                            |
+| timeSinceTrackerReady    | Time (in milliseconds) since the tracker was initialized (PLAYER_READY).                                                                           |
+| timeSinceLastHeartbeat   | Time (in milliseconds) since the last heartbeat event.                                                                                             |
+| timeSinceBufferBegin     | Time (in milliseconds) since the last buffer event began.                                                                                          |
+| timeSincePaused          | Time (in milliseconds) since the video was last paused.                                                                                            |
+| timeSinceLastError       | Time (in milliseconds) since the last content error occurred. Only included after an error has occurred.                                            |
+| numberOfVideos           | Number of videos played in this session.                                                                                                           |
+| numberOfErrors           | Number of errors occurred in this session.                                                                                                         |
+| trackerName              | Name of the tracker/agent.                                                                                                                         |
+| trackerVersion           | Version of the tracker/agent.                                                                                                                      |
 
 #### List of possible Video Actions
 
@@ -157,7 +168,7 @@ QOE_AGGREGATE events carry all standard VideoAction attributes (viewId, viewSess
 | asnLongitude             | The longitude of the geographic center of the postal code where the Autonomous System Network is registered. This is not the end user's longitude. |
 | asnOrganization          | The organization that owns the Autonomous System Number. Often an ISP, sometimes a private company or institution.                                 |
 | timestamp                | The time (date, hour, minute, second) at which the interaction occurred.                                                                           |
-| elapsedTime              | Time that has passed since the last event.                                                                                                         |
+| elapsedTime              | Active content watched between two consecutive heartbeats, in milliseconds.                                                                                                         |
 | instrumentation.provider | Player/agent name.                                                                                                                                 |
 | instrumentation.name     | Name of the instrumentation collecting the data.                                                                                                   |
 | instrumentation.version  | Agent’s version.                                                                                                                                   |
@@ -201,7 +212,6 @@ QOE_AGGREGATE events carry all standard VideoAction attributes (viewId, viewSess
 | contentTitle             | The title of the video.                                                                                                                            |
 | errorMessage                | Message of the error.                                                                                                                                 |
 | errorCode                | Error code if it's known.                                                                                                                          |
-| backTrace                | Stack trace of the error.                                                                                                                          |
 | isBackgroundEvent        | If the player is hidden by another window.                                                                                                         |
 | contentSrc               | Content source URL.                                                                                                                                |
 | contentCdn               | Content CDN URL.                                                                                                                                   |
@@ -209,7 +219,7 @@ QOE_AGGREGATE events carry all standard VideoAction attributes (viewId, viewSess
 | asnLatitude              | The latitude of the geographic center of the postal code where the Autonomous System Network is registered. This is not the end user's latitude.   |
 | asnLongitude             | The longitude of the geographic center of the postal code where the Autonomous System Network is registered. This is not the end user's longitude. |
 | asnOrganization          | The organization that owns the Autonomous System Number. Often an ISP, sometimes a private company or institution.                                 |
-| elapsedTime              | Time that has passed since the last event.                                                                                                         |
+| elapsedTime              | Active content watched between two consecutive heartbeats, in milliseconds.                                                                                                         |
 | timestamp                | The time (date, hour, minute, second) at which the interaction occurred.                                                                           |
 | instrumentation.provider | Player/agent name.                                                                                                                                 |
 | instrumentation.name     | Name of the instrumentation collecting the data.                                                                                                   |

--- a/README.md
+++ b/README.md
@@ -354,7 +354,22 @@ Limits for custom attributes added to default mobile events:
 
 ### Live Stream Configuration
 
-For live streams, the agent automatically uses a shorter harvest cycle (30–60 seconds) for near-real-time data transmission.
+The agent uses a separate harvest interval for VOD and LIVE content:
+
+| Content Type | Default Interval | Range | Builder Method |
+| --- | --- | --- | --- |
+| VOD | 300s (Mobile) / 180s (TV) | 5–300s | `.withHarvestCycle(seconds)` |
+| LIVE | 30s (Mobile) / 10s (TV) | 1–60s | `.withLiveHarvestCycle(seconds)` |
+
+```swift
+// Live stream — flush every 10 seconds on TV, 30s on Mobile (or override)
+let tracker = NewRelicVideoAgent.build(
+    withHarvestCycle: 300,
+    withLiveHarvestCycle: 10
+)
+```
+
+> **Note:** Harvest intervals are immutable after `.build()`.
 
 ## API Reference
 


### PR DESCRIPTION
Adds `### Live Stream Configuration` section to README.md.

Part of [PRD: Harvest Cycle Configuration Documentation](https://newrelic.atlassian.net/wiki/spaces/VERTSOL/pages/5952111079/PRD+Harvest+Cycle+Configuration+Documentation).