### PR TITLE
fix: don't close buffer window prematurely when pausing mid-rebuffer

### DIFF
--- a/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
+++ b/NRAVPlayerTracker/NRAVPlayerTracker/Tracker/NRTrackerAVPlayer.m
@@ -242,14 +242,19 @@
     else if ([keyPath isEqualToString:@"currentItem.playbackBufferEmpty"] && self.state.isSeeking && self.state.isPaused) {
         [self sendBufferStart];
     }
-    else if ([keyPath isEqualToString:@"currentItem.playbackBufferFull"] && self.state.isSeeking && self.state.isPaused) {
+    else if ([keyPath isEqualToString:@"currentItem.playbackBufferFull"] && self.state.isPaused) {
+        // NR-531411: not gated on isSeeking anymore — a plain (non-seek) rebuffer
+        // that resolves while the user is paused needs to close the buffer window
+        // here too, since the timeControlStatus handler below now defers to this
+        // observer for that case instead of closing it prematurely.
         [self sendBufferEnd];
         [self sendSeekEnd];
     }
     else if ([keyPath isEqualToString:@"currentItem.playbackLikelyToKeepUp"]) {
         [self sendRequest];
 
-        if (self.state.isSeeking && self.state.isPaused && self.playerInstance.currentItem.playbackLikelyToKeepUp) {
+        if (self.state.isPaused && self.playerInstance.currentItem.playbackLikelyToKeepUp) {
+            // NR-531411: same broadening as playbackBufferFull above.
             [self sendBufferEnd];
             [self sendSeekEnd];
         }
@@ -290,7 +295,20 @@
                 [self sendBufferStart];
             }
             else {
-                [self sendBufferEnd];
+                // NR-531411: timeControlStatus reflects playback intent, not buffer
+                // health — it can flip to Paused as soon as the user pauses, well
+                // before the underlying network buffer has actually filled. If
+                // we're mid-buffer when that happens, don't close the buffer window
+                // here; let the playbackLikelyToKeepUp/playbackBufferFull observers
+                // above close it once buffering genuinely resolves. (If buffering
+                // already resolved via one of those observers by the time we get
+                // here, self.state.isBuffering is already false and sendBufferEnd
+                // below is a safe no-op either way.)
+                BOOL isPausingDuringActiveBuffer = self.state.isBuffering &&
+                    self.playerInstance.timeControlStatus == AVPlayerTimeControlStatusPaused;
+                if (!isPausingDuringActiveBuffer) {
+                    [self sendBufferEnd];
+                }
                 [self sendSeekEnd];
             }
         } else {


### PR DESCRIPTION
## Summary
- AVPlayer's `timeControlStatus` reflects playback intent, not buffer health — pausing during a rebuffer flips `timeControlStatus` to `Paused` immediately, well before the underlying network buffer has actually filled. The `timeControlStatus` KVO handler's `else` branch was unconditionally calling `sendBufferEnd()` on that transition, closing the buffer window before buffering had genuinely resolved — understating rebuffer duration (opposite symptom from the Roku `NR-531410` bug: there `BUFFER_END` was lost/delayed, here it fires too early).
- Broadens the existing `playbackBufferFull`/`playbackLikelyToKeepUp` observers (previously scoped to `isSeeking && isPaused`) to also cover a plain pause during buffering, and defers to them from the `timeControlStatus` handler whenever a pause happens while `state.isBuffering` is still true.
- `sendBufferEnd`/`sendSeekEnd` are already idempotent (`goBufferEnd`/`goSeekEnd` guard on `isBuffering`/`isSeeking` in `NRTrackerState.m`), so this can't introduce a duplicate or lost event — confirmed by tracing both the seek and non-seek paths through the state machine.
- Note: `self.state.isPaused` is only updated asynchronously via a 0.5s periodic timer polling `rate` — not reliable to check synchronously inside the `timeControlStatus` KVO callback. The suppression check in that handler instead reads `self.playerInstance.timeControlStatus` directly (available synchronously) combined with `self.state.isBuffering` (set synchronously by `sendBufferStart` earlier in the same method).

Fixes NR-531411.

## Test plan
- [ ] On-device/simulator: start playback, trigger a rebuffer, pause while the buffer spinner is still showing, confirm `CONTENT_BUFFER_END` does not fire until the buffer has actually recovered (not immediately on pause).
- [ ] Confirm the existing seek-while-paused rebuffer path (unchanged behavior) still closes the buffer window correctly.
- [ ] Confirm a plain buffer-then-resume-without-pausing (the common case) is unaffected.
- [ ] Confirm no duplicate `CONTENT_BUFFER_END` events in either path.